### PR TITLE
Add attribute support for CdkResource.

### DIFF
--- a/examples/appsvc/index.ts
+++ b/examples/appsvc/index.ts
@@ -5,6 +5,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as cdk from "@pulumi/cdk";
 import { Construct } from "constructs";
 import * as aws from "@pulumi/aws";
+import { CfnOutput } from "aws-cdk-lib";
 
 const defaultVpc = pulumi.output(aws.ec2.getVpc({ default: true }));
 const defaultVpcSubnets = defaultVpc.id.apply(id => aws.ec2.getSubnetIds({ vpcId: id }));
@@ -43,7 +44,7 @@ const atg = new aws.lb.TargetGroup("app-tg", {
 // 	policyArn: "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
 // });
 
-new cdk.CdkStackComponent("teststack", (scope: Construct, parent: cdk.CdkStackComponent) => {
+const stack = new cdk.CdkStackComponent("teststack", (scope: Construct, parent: cdk.CdkStackComponent) => {
     const adapter = new cdk.AwsPulumiAdapter(scope, "adapter", parent);
 
     const cluster = new ecs.CfnCluster(adapter, "clusterstack");
@@ -102,5 +103,9 @@ new cdk.CdkStackComponent("teststack", (scope: Construct, parent: cdk.CdkStackCo
     });
     service.addDependsOn(listener);
 
+    new CfnOutput(adapter, "serviceName", { value: service.attrName });
+
     return adapter;
 });
+
+export const serviceName = stack.outputs["serviceName"];

--- a/src/interop.ts
+++ b/src/interop.ts
@@ -43,11 +43,26 @@ export function normalize(value: any): any {
 }
 
 export class CdkResource extends pulumi.CustomResource {
-    constructor(name: string, type: string, args: any, opts?: pulumi.CustomResourceOptions) {
+    constructor(
+        name: string,
+        type: string,
+        properties: any,
+        attributes: string[],
+        opts?: pulumi.CustomResourceOptions,
+    ) {
         const res = type.split('::')[2];
         const mod = moduleName(type);
         const resourceName = `aws-native:${mod}:${res}`;
-        debug(`CdkResource ${resourceName}: ${JSON.stringify(args)}`);
+
+        debug(`CdkResource ${resourceName}: ${JSON.stringify(properties)}, ${JSON.stringify(attributes)}`);
+
+        // Prepare an args bag with placeholders for output attributes.
+        const args: any = {};
+        for (const k of attributes) {
+            args[k] = undefined;
+        }
+        Object.assign(args, properties);
+
         // console.debug(`CdkResource opts: ${JSON.stringify(opts)}`)
         super(resourceName, name, args, opts);
     }
@@ -71,7 +86,7 @@ export class CdkComponent extends pulumi.ComponentResource {
             const sourceProps = (value as any).Properties;
             console.debug(`resource[${key}] Type:${typeName} props: ${sourceProps}`);
             opts = opts || { parent: this };
-            new CdkResource(key, typeName, normalize(sourceProps), opts);
+            new CdkResource(key, typeName, normalize(sourceProps), [], opts);
         });
     }
 }


### PR DESCRIPTION
Add a new parameter to the CdkResource constructor that accepts a list
of output attribute names for the resource. This allows the Node SDK to
populate the resource's output attributes. In the CDK adapter, populate
this list of attributes for a resource that represents a CFN element
by scraping unresolved tokens that target the element off of the
element's properties and converting them back into attribute names.

Contributes to #6.