### PR TITLE
Register component resources for L2+ constructs.

### DIFF
--- a/examples/alb/Pulumi.yaml
+++ b/examples/alb/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-aws-cdk-alb
+runtime: nodejs
+description: ALB example for CDK

--- a/examples/alb/index.ts
+++ b/examples/alb/index.ts
@@ -1,0 +1,45 @@
+import * as autoscaling from 'aws-cdk-lib/aws-autoscaling';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import * as pulumi from "@pulumi/pulumi";
+import * as cdk from "@pulumi/cdk";
+import { Construct } from "constructs";
+import { CfnOutput } from "aws-cdk-lib";
+
+const stack = new cdk.CdkStackComponent("teststack", (scope: Construct, parent: cdk.CdkStackComponent) => {
+    const adapter = new cdk.AwsPulumiAdapter(scope, "adapter", parent);
+
+    const vpc = new ec2.Vpc(adapter, 'VPC');
+
+    const asg = new autoscaling.AutoScalingGroup(adapter, 'ASG', {
+      vpc,
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T2, ec2.InstanceSize.MICRO),
+      machineImage: new ec2.AmazonLinuxImage(),
+    });
+
+    const lb = new elbv2.ApplicationLoadBalancer(adapter, 'LB', {
+      vpc,
+      internetFacing: true
+    });
+
+    const listener = lb.addListener('Listener', {
+      port: 80,
+    });
+
+    listener.addTargets('Target', {
+      port: 80,
+      targets: [asg]
+    });
+
+    listener.connections.allowDefaultPortFromAnyIpv4('Open to the world');
+
+    asg.scaleOnRequestCount('AModestLoad', {
+      targetRequestsPerMinute: 60,
+    });
+
+    new CfnOutput(adapter, "url", { value: lb.loadBalancerDnsName });
+
+    return adapter;
+});
+
+export const url = stack.outputs["url"];

--- a/examples/alb/package.json
+++ b/examples/alb/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "pulumi-aws-cdk",
+    "devDependencies": {
+        "@types/node": "^10.0.0"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^4.6.0",
+        "@pulumi/aws-native": "^0.8.0",
+        "@pulumi/pulumi": "^3.0.0",
+        "aws-cdk-lib": "^2.20.0",
+        "constructs": "^10.0.111"
+    },
+    "peerDependencies": {
+        "@pulumi/cdk": "^0.0.1"
+    }
+}

--- a/examples/alb/tsconfig.json
+++ b/examples/alb/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/examples/apprunner/index.ts
+++ b/examples/apprunner/index.ts
@@ -5,7 +5,6 @@ import { Construct } from "constructs";
 import { Service, Source } from "@aws-cdk/aws-apprunner-alpha"
 import { CfnOutput } from 'aws-cdk-lib';
 
-
 const stack = new CdkStackComponent("teststack", (scope: Construct, parent: CdkStackComponent) => {
     const adapter = new AwsPulumiAdapter(scope, "adapter", parent);
 

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -37,6 +37,17 @@ func TestCronLambda(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestALB(t *testing.T) {
+	t.Skipf("skipping due to missing support for `Fn::Select`")
+
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: filepath.Join(getCwd(t), "alb"),
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	base := getBaseOptions(t)
 	baseJS := base.With(integration.ProgramTestOptions{

--- a/tests/graph.ts
+++ b/tests/graph.ts
@@ -57,7 +57,7 @@ describe('Graph tests', () => {
         ], done);
     });
 
-    it('Test sort for ASG example', done => {
+    it('Test sort for ALB example', done => {
         testGraph(stack => {
             const vpc = new ec2.Vpc(stack, 'VPC');
 


### PR DESCRIPTION
These changes add support for registering a component resource per L2+
construct in the construct tree and properly parenting its children. As
part of these changes, the naming scheme for the resources created by
the adapter has changed to incorporate the StackComponent's name and
each construct's path (rather than its logical ID). This will allow
multiple instances of a construct to be created within the same Pulumi
program without conflicting URNs.

Contributes to #6.