### PR TITLE
Implement more intrinsics + pseudo-params.

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -38,7 +38,7 @@ func TestCronLambda(t *testing.T) {
 }
 
 func TestALB(t *testing.T) {
-	t.Skipf("skipping due to missing support for `Fn::Select`")
+	t.Skipf("skipping due to missing support for `AWS::EC2::EIP`")
 
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{

--- a/src/cfn.ts
+++ b/src/cfn.ts
@@ -1,3 +1,8 @@
+export interface CloudFormationParameter {
+    readonly Type: string;
+    readonly Default?: any;
+}
+
 export interface CloudFormationResource {
     readonly Type: string;
     readonly Properties: any;
@@ -6,6 +11,7 @@ export interface CloudFormationResource {
 }
 
 export interface CloudFormationTemplate {
+    Parameters?: { [id: string]: CloudFormationParameter };
     Resources?: { [id: string]: CloudFormationResource };
     Conditions?: { [id: string]: any };
     Outputs?: { [id: string]: any };

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1,3 +1,4 @@
+import { debug } from '@pulumi/pulumi/log';
 import { Stack, CfnElement, Token } from 'aws-cdk-lib';
 import { Construct, ConstructOrder } from 'constructs';
 import { CloudFormationTemplate } from './cfn';
@@ -53,9 +54,11 @@ export class GraphBuilder {
             this.constructNodes.set(construct, node);
             if (CfnElement.isCfnElement(construct)) {
                 const logicalId = this.host.resolve(construct.logicalId);
+                debug(`adding node for ${logicalId}`);
                 this.cfnElementNodes.set(logicalId, node);
 
                 for (const [logicalId, r] of Object.entries(template!.Resources || {})) {
+                    debug(`adding node for ${logicalId}`);
                     this.cfnElementNodes.set(logicalId, node);
                 }
             }
@@ -157,10 +160,11 @@ export class GraphBuilder {
         }
         const targetLogicalId = args;
 
+        debug(`ref to ${args}`);
         if (!targetLogicalId.startsWith('AWS::')) {
             const targetNode = this.cfnElementNodes.get(targetLogicalId);
             if (targetNode === undefined) {
-                console.warn(`missing node for target element ${targetLogicalId}`);
+                debug(`missing node for target element ${targetLogicalId}`);
             } else {
                 source.outgoingEdges.add(targetNode);
                 targetNode.incomingEdges.add(source);


### PR DESCRIPTION
- Implement Fn::{Select,Split,Base64,Cidr,GetAZs}
- Lift intrinsics over outputs, using all/apply where necessary
- Implement support for SSM parameters with default values
- Implement support for the AWS::{AccountId,NoValue,Region,URLSuffix}
  pseudo-parameters (the last of which requires a change in aws-native)

With these changes, the ALB example is close to running, and is
currently blocked on a lack of a mapping for AWS::EC2::EIP.