### PR TITLE
Simplify the user-facing API.

### DIFF
--- a/examples/alb/index.ts
+++ b/examples/alb/index.ts
@@ -4,9 +4,9 @@ import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import * as pulumi from '@pulumi/pulumi';
 import * as pulumicdk from '@pulumi/cdk';
 import { Construct } from 'constructs';
-import { CfnOutput } from 'aws-cdk-lib';
+import { CfnOutput, Stack } from 'aws-cdk-lib';
 
-class AlbStack extends pulumicdk.Stack {
+class AlbStack extends Stack {
     constructor(scope: Construct, id: string) {
         super(scope, id);
 
@@ -42,6 +42,5 @@ class AlbStack extends pulumicdk.Stack {
     }
 }
 
-const stack = pulumicdk.Stack.create('teststack', AlbStack);
-
+const stack = new pulumicdk.Stack('teststack', AlbStack);
 export const url = stack.outputs['url'];

--- a/examples/apprunner/index.ts
+++ b/examples/apprunner/index.ts
@@ -1,9 +1,9 @@
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as pulumi from '@pulumi/pulumi';
-import { Stack } from '@pulumi/cdk/interop-aspect';
+import * as pulumicdk from '@pulumi/cdk';
 import { Construct } from 'constructs';
 import { Service, Source } from '@aws-cdk/aws-apprunner-alpha';
-import { CfnOutput } from 'aws-cdk-lib';
+import { CfnOutput, Stack } from 'aws-cdk-lib';
 
 class AppRunnerStack extends Stack {
     constructor(scope: Construct, id: string) {
@@ -20,5 +20,5 @@ class AppRunnerStack extends Stack {
     }
 }
 
-const stack = Stack.create('teststack', AppRunnerStack);
+const stack = new pulumicdk.Stack('teststack', AppRunnerStack);
 export const url = stack.outputs['url'];

--- a/examples/appsvc/index.ts
+++ b/examples/appsvc/index.ts
@@ -5,7 +5,7 @@ import * as pulumi from '@pulumi/pulumi';
 import * as pulumicdk from '@pulumi/cdk';
 import { Construct } from 'constructs';
 import * as aws from '@pulumi/aws';
-import { CfnOutput } from 'aws-cdk-lib';
+import { CfnOutput, Stack } from 'aws-cdk-lib';
 
 const defaultVpc = pulumi.output(aws.ec2.getVpc({ default: true }));
 const defaultVpcSubnets = defaultVpc.id.apply((id) => aws.ec2.getSubnetIds({ vpcId: id }));
@@ -48,7 +48,7 @@ const atg = new aws.lb.TargetGroup('app-tg', {
 // 	policyArn: "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
 // });
 
-class ClusterStack extends pulumicdk.Stack {
+class ClusterStack extends Stack {
     constructor(scope: Construct, id: string) {
         super(scope, id);
 
@@ -119,5 +119,5 @@ class ClusterStack extends pulumicdk.Stack {
     }
 }
 
-const stack = pulumicdk.Stack.create('teststack', ClusterStack);
+const stack = new pulumicdk.Stack('teststack', ClusterStack);
 export const serviceName = stack.outputs['serviceName'];

--- a/examples/cron-lambda/adapter.ts
+++ b/examples/cron-lambda/adapter.ts
@@ -1,0 +1,61 @@
+import { CfnElement } from 'aws-cdk-lib';
+import * as pulumi from '@pulumi/pulumi';
+import * as aws from '@pulumi/aws';
+import { Construct } from 'constructs';
+
+interface target {
+    arn: pulumi.Input<string>;
+    id: string;
+}
+
+export function remapCloudControlResource(
+    element: CfnElement,
+    logicalId: string,
+    typeName: string,
+    props: any,
+    options: pulumi.ResourceOptions,
+): { [key: string]: pulumi.CustomResource } | undefined {
+    switch (typeName) {
+        case 'AWS::Events::Rule':
+            const resources: { [key: string]: pulumi.CustomResource } = {};
+            const rule = new aws.cloudwatch.EventRule(
+                logicalId,
+                {
+                    scheduleExpression: props['scheduleExpression'],
+                    isEnabled: props['state'] == 'ENABLED' ? true : props.State === 'DISABLED' ? false : undefined,
+                    description: props.Description,
+                    eventBusName: props['eventBusName'] ?? undefined,
+                    eventPattern: props['eventPattern'] ?? undefined,
+                    roleArn: props['roleArn'] ?? undefined,
+                },
+                options,
+            );
+            resources[logicalId] = rule;
+            const targets: target[] = props['targets'] ?? [];
+            for (const t of targets) {
+                resources[t.id] = new aws.cloudwatch.EventTarget(
+                    t.id,
+                    {
+                        arn: t.arn,
+                        rule: rule.name,
+                    },
+                    options,
+                );
+            }
+            return resources;
+        case 'AWS::Lambda::Permission':
+            const perm = new aws.lambda.Permission(
+                logicalId,
+                {
+                    action: props['action'],
+                    function: props['functionName'],
+                    principal: props['principal'],
+                    sourceArn: props['sourceArn'] ?? undefined,
+                },
+                options,
+            );
+            return { [logicalId]: perm };
+    }
+
+    return undefined;
+}

--- a/tests/basic.ts
+++ b/tests/basic.ts
@@ -1,4 +1,5 @@
 import * as pulumi from "@pulumi/pulumi";
+import * as cdk from "aws-cdk-lib";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import { Stack } from "../src/interop-aspect";
 import { Construct } from "constructs";
@@ -9,7 +10,7 @@ import * as output from "../src/output";
 mocks.setMocks();
 
 function testStack(fn: (scope: Construct) => void, done: any) {
-    class TestStack extends Stack {
+    class TestStack extends cdk.Stack {
         constructor(scope: Construct, id: string) {
             super(scope, id);
 
@@ -17,7 +18,7 @@ function testStack(fn: (scope: Construct) => void, done: any) {
         }
     }
 
-    const s = Stack.create('teststack', TestStack);
+    const s = new Stack('teststack', TestStack);
     s.urn.apply(() => done());
 }
 


### PR DESCRIPTION
- Remove the cdk.Stack subclass
- Rename StackComponent to Stack
- Move `remapCloudControlResource` to an options bag for Stack