### PR TITLE
Use nicer names for S3 assets where possible.

### DIFF
--- a/src/interop.ts
+++ b/src/interop.ts
@@ -90,6 +90,12 @@ export class CfnResource extends pulumi.CustomResource {
     }
 }
 
+export const JSII_RUNTIME_SYMBOL = Symbol.for('jsii.rtti');
+
+export function getFqn(construct: IConstruct): string | undefined {
+    return Object.getPrototypeOf(construct).constructor[JSII_RUNTIME_SYMBOL]?.fqn;
+}
+
 export class CdkConstruct extends pulumi.ComponentResource {
     constructor(name: string | undefined, construct: IConstruct, options?: pulumi.ComponentResourceOptions) {
         const constructType = construct.constructor.name || 'Construct';


### PR DESCRIPTION
Prior to asset conversion, crawl each stack's node tree in search of S3
assets and build a map from asset paths to S3 asset objects. When
converting a file asset, derive its name from the path of its
corresponding S3 asset object, if any.