### PR TITLE
Use Node 14.17.x.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: 17.x
+          node-version: 14.17.x
           registry-url: https://registry.npmjs.org
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: 17.x
+          node-version: 14.17.x
           registry-url: https://registry.npmjs.org
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: 17.x
+          node-version: 14.17.x
           registry-url: https://registry.npmjs.org
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: 17.x
+          node-version: 14.17.x
           registry-url: https://registry.npmjs.org
       - name: Install Go
         uses: actions/setup-go@v2

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/archiver": "^5.3.1",
     "@types/chai": "^4.3.1",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^17.0.23",
+    "@types/node": "^14.17.0",
     "@typescript-eslint/eslint-plugin": "^5.19.0",
     "@typescript-eslint/parser": "^5.19.0",
     "chai": "^4.3.6",

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -498,7 +498,7 @@ class StackConverter extends ArtifactConverter {
                 return lift(([delim, str]) => str.split(delim), this.processIntrinsics(params));
 
             case 'Fn::Base64':
-                return lift(([str]) => btoa(str), this.processIntrinsics(params));
+                return lift(([str]) => Buffer.from(str).toString('base64'), this.processIntrinsics(params));
 
             case 'Fn::Cidr':
                 return lift(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "outDir": "lib",
-        "target": "es2016",
+        "target": "es2020",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -276,10 +276,15 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^17.0.23":
+"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0":
   version "17.0.23"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
   integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
+
+"@types/node@^14.17.0":
+  version "14.18.16"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.16.tgz#878f670ba3f00482bf859b6550b6010610fc54b5"
+  integrity sha512-X3bUMdK/VmvrWdoTkz+VCn6nwKwrKCFTHtqwBIaQJNx4RUIBBUFXM00bqPz/DsDd+Icjmzm6/tyYZzeGVqb6/Q==
 
 "@types/tmp@^0.0.33":
   version "0.0.33"


### PR DESCRIPTION
- Replace `btoa` with `Buffer.from(s).toString('base64')`
- Target ES2020
- Use Node 14.17.x types
- Use Node 14.17.x in CI