### PR TITLE
Adding a publish step for main and release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,8 +58,10 @@ jobs:
           go-version: 1.16.x
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
-      - name: Build SDK
-        run: make build_sdk
+      - name: Install packages
+        run: yarn install
+      - name: Run build
+        run: yarn run build
       - name: Run unit tests
         run: yarn run test
       - name: yarn link

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,10 @@ jobs:
           go-version: 1.16.x
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
-      - name: Build SDK
-        run: make build_sdk
+      - name: Install packages
+        run: yarn install
+      - name: Run build
+        run: yarn run build
       - name: Run unit tests
         run: yarn run test
       - name: yarn link

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,0 @@
-build_sdk:: VERSION := $(shell pulumictl get version --language javascript)
-build_sdk::
-	yarn install && \
-	yarn run build && \
-	sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./lib/package.json && \
-	rm ./lib/package.json.bak

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typescript": "^4.6.3"
   },
   "scripts": {
-    "build": "tsc && cp package.json README.md LICENSE lib/",
+    "build": "tsc && cp package.json README.md LICENSE lib/ && sed -i.bak -e \"s/\\${VERSION}/$(pulumictl get version --language javascript)/g\" lib/package.json && rm lib/package.json.bak",
     "lint": "./node_modules/.bin/eslint src --ext .js,.jsx,.ts,.tsx",
     "format": "./node_modules/.bin/prettier --write \"src/**/*.ts\" \"examples/**/*.ts\"",
     "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha -r ts-node/register 'tests/**/*.ts'",


### PR DESCRIPTION
Fixes: #22

We are using pulumictl to calculate the current version and then
we are writing that version to the ./lib/package.json

When the tests have run successfully, we then publish a dev package
out of the lib folder for main builds and a latest tag as part of
the release build
