### PR TITLE
Re-enable examples in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,15 +73,14 @@ jobs:
         uses: haveyoudebuggedit/gotestfmt-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      #- name: Run examples
-      #  run: yarn run test-examples-gotestfmt
+      - name: Run examples
+        run: yarn run test-examples-gotestfmt
       - name: Publish Dev Package
         uses: JS-DevTools/npm-publish@v1
         with:
           access: "public"
           token: ${{ secrets.NPM_TOKEN }}
           package: ${{github.workspace}}/lib/package.json
-          tag: latest
 name: release
 "on":
   push:


### PR DESCRIPTION
Also removing the tag `latest` argument.