### PR TITLE
Publish from main only if version bump occurs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,7 @@ jobs:
           token: ${{ secrets.NPM_TOKEN }}
           package: ${{github.workspace}}/lib/package.json
           tag: dev
+          check-version: true
 name: main
 "on":
   schedule:


### PR DESCRIPTION
Avoid build failures on main e.g.: https://github.com/pulumi/pulumi-cdk/runs/6650009887?check_suite_focus=true