### PR TITLE
Support specifying stack properties

### DIFF
--- a/examples/ecscluster/Pulumi.yaml
+++ b/examples/ecscluster/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-cdk-ecscluster
+runtime: nodejs
+description: ECS Cluster

--- a/examples/ecscluster/index.ts
+++ b/examples/ecscluster/index.ts
@@ -1,0 +1,34 @@
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as pulumi from '@pulumi/pulumi';
+import * as pulumicdk from '@pulumi/cdk';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as pulumiaws from "@pulumi/aws-native";
+
+class ECSClusterStack extends pulumicdk.Stack {
+    clusterArn: pulumi.Output<string>;
+
+    constructor(id: string, options?: pulumicdk.StackOptions) {
+        super(id, options);
+
+        const vpc = ec2.Vpc.fromLookup(this, 'MyVpc', {
+            isDefault: true,
+        })
+        const cluster = new ecs.Cluster(this, 'fargate-service-autoscaling', { vpc });
+
+        this.clusterArn = this.asOutput(cluster.clusterArn);
+
+        this.synth();
+    }
+}
+
+export const clusterArn = pulumiaws.getAccountId().then(account => {
+    const stack = new ECSClusterStack('teststack', {
+        props: {
+            env: {
+                region: pulumiaws.config.region,
+                account: account.accountId,
+            }
+        }
+    });
+    return stack.clusterArn;
+});

--- a/examples/ecscluster/package.json
+++ b/examples/ecscluster/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "pulumi-aws-cdk",
+    "devDependencies": {
+        "@types/node": "^10.0.0"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^4.6.0",
+        "@pulumi/aws-native": "^0.16.1",
+        "@pulumi/pulumi": "^3.0.0",
+        "aws-cdk-lib": "^2.20.0",
+        "constructs": "^10.0.111"
+    },
+    "peerDependencies": {
+        "@pulumi/cdk": "^0.0.1"
+    }
+}

--- a/examples/ecscluster/tsconfig.json
+++ b/examples/ecscluster/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+      "strict": true,
+      "outDir": "bin",
+      "target": "es2016",
+      "module": "commonjs",
+      "moduleResolution": "node",
+      "sourceMap": true,
+      "experimentalDecorators": true,
+      "pretty": true,
+      "noFallthroughCasesInSwitch": true,
+      "noImplicitReturns": true,
+      "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+      "index.ts"
+  ]
+}

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -30,6 +30,15 @@ func TestAppSvc(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestECSCluster(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: filepath.Join(getCwd(t), "ecscluster"),
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestAppRunner(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -58,6 +58,11 @@ import { zipDirectory } from './zip';
  */
 export interface StackOptions extends pulumi.ComponentResourceOptions {
     /**
+     * Specify the CDK Stack properties to asociate with the stack.
+     */
+    props?: cdk.StackProps;
+
+    /**
      * Defines a mapping to override and/or provide an implementation for a CloudFormation resource
      * type that is not (yet) implemented in the AWS Cloud Control API (and thus not yet available in
      * the Pulumi AWS Native provider). Pulumi code can override this method to provide a custom mapping
@@ -165,7 +170,7 @@ export class Stack extends cdk.Stack {
             },
         });
 
-        super(app, name);
+        super(app, name, options?.props);
 
         this.app = app;
         this.options = options;


### PR DESCRIPTION
Enables passing stack properties to the underlying CDK stack.

This is particularly useful for specifying `region` and `account` env variables.

These are needed for non-"environment agnostic" stacks to function correctly.

Fixes #47.
Fixes #48.