### PR TITLE
Bump CI to Node 18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: 14.17.x
+          node-version: 18.17.x
           registry-url: https://registry.npmjs.org
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
@@ -51,12 +51,12 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: 14.17.x
+          node-version: 18.17.x
           registry-url: https://registry.npmjs.org
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.20.x
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
       - name: Install packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: 14.17.x
+          node-version: 18.17.x
           registry-url: https://registry.npmjs.org
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
@@ -51,12 +51,12 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: 14.17.x
+          node-version: 18.17.x
           registry-url: https://registry.npmjs.org
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.20.x
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
       - name: Install packages

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: 14.17.x
+          node-version: 18.17.x
           registry-url: https://registry.npmjs.org
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
@@ -63,12 +63,12 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: 14.17.x
+          node-version: 18.17.x
           registry-url: https://registry.npmjs.org
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.20.x
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
       - name: Install packages

--- a/examples/api-websocket-lambda-dynamodb/index.ts
+++ b/examples/api-websocket-lambda-dynamodb/index.ts
@@ -36,7 +36,7 @@ class ChatAppStack extends pulumicdk.Stack {
         const connectFunc = new Function(this, 'connect-lambda', {
             code: new AssetCode('./onconnect'),
             handler: 'app.handler',
-            runtime: Runtime.NODEJS_12_X,
+            runtime: Runtime.NODEJS_16_X,
             timeout: Duration.seconds(300),
             memorySize: 256,
             environment: {
@@ -49,7 +49,7 @@ class ChatAppStack extends pulumicdk.Stack {
         const disconnectFunc = new Function(this, 'disconnect-lambda', {
             code: new AssetCode('./ondisconnect'),
             handler: 'app.handler',
-            runtime: Runtime.NODEJS_12_X,
+            runtime: Runtime.NODEJS_16_X,
             timeout: Duration.seconds(300),
             memorySize: 256,
             environment: {
@@ -62,7 +62,7 @@ class ChatAppStack extends pulumicdk.Stack {
         const messageFunc = new Function(this, 'message-lambda', {
             code: new AssetCode('./sendmessage'),
             handler: 'app.handler',
-            runtime: Runtime.NODEJS_12_X,
+            runtime: Runtime.NODEJS_16_X,
             timeout: Duration.seconds(300),
             memorySize: 256,
             initialPolicy: [

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -49,5 +49,6 @@ func getBaseOptions(t *testing.T) integration.ProgramTestOptions {
 		ExpectRefreshChanges: true,
 		SkipRefresh:          true,
 		Quick:                true,
+		Verbose:              true,
 	}
 }

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -49,6 +49,5 @@ func getBaseOptions(t *testing.T) integration.ProgramTestOptions {
 		ExpectRefreshChanges: true,
 		SkipRefresh:          true,
 		Quick:                true,
-		Verbose:              true,
 	}
 }

--- a/examples/fargate/package.json
+++ b/examples/fargate/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^4.6.0",
-        "@pulumi/aws-native": "^0.16.1",
+        "@pulumi/aws-native": "^0.70.0",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "^2.20.0",
         "constructs": "^10.0.111"


### PR DESCRIPTION
Using LTS versions.

A dependency updated to require Node 16 awhile ago which broke our tests.  https://github.com/aws/constructs/pull/1682

Use newer `aws-native` version in a test.

Fix up networking configuration in fargate test.

Fixes #81.
