### PR TITLE
Retry flakey integration tests

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -63,6 +63,7 @@ func TestALB(t *testing.T) {
 		With(integration.ProgramTestOptions{
 			Dir:        filepath.Join(getCwd(t), "alb"),
 			NoParallel: true, // Resources may collide with TestFargate
+			RetryFailedSteps: true, // Workaround for https://github.com/pulumi/pulumi-aws-native/issues/1186
 		})
 
 	integration.ProgramTest(t, &test)
@@ -73,6 +74,7 @@ func TestFargate(t *testing.T) {
 		With(integration.ProgramTestOptions{
 			Dir:        filepath.Join(getCwd(t), "fargate"),
 			NoParallel: true,
+			RetryFailedSteps: true, // Workaround for https://github.com/pulumi/pulumi-aws-native/issues/1186
 		})
 
 	integration.ProgramTest(t, &test)


### PR DESCRIPTION
As per, https://github.com/pulumi/pulumi-aws-native/issues/1186 we're seeing intermittent errors in the creation of `aws-native:ec2:SubnetRouteTableAssociation` This change enables retries for the affected tests to reduce the noise until we have an upstream fix 

Fixes https://github.com/pulumi/pulumi-cdk/issues/96