### PR TITLE
chore: update workflows and scripts

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -4,8 +4,6 @@ description: Runs build
 runs:
   using: "composite"
   steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -4,20 +4,24 @@ description: Runs build
 runs:
   using: "composite"
   steps:
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.10.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18.19.x
-          registry-url: https://registry.npmjs.org
-      - name: Install Yarn
-        run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
-      - name: Install packages
-        run: yarn install --frozen-lockfile
-      - name: Run build
-        run: yarn run build
-      - name: Run unit tests
-        run: yarn run test
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.10.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18.19.x
+        registry-url: https://registry.npmjs.org
+    - name: Install Yarn
+      shell: bash
+      run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
+    - name: Install packages
+      shell: bash
+      run: yarn install --frozen-lockfile
+    - name: Run build
+      shell: bash
+      run: yarn run build
+    - name: Run unit tests
+      shell: bash
+      run: yarn run test

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -5,13 +5,13 @@ runs:
   using: "composite"
   steps:
     - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.10.0
+      uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/pulumictl
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: 18.19.x
+        node-version: 18.x
         registry-url: https://registry.npmjs.org
     - name: Install Yarn
       shell: bash

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,25 @@
+name: Build and Test
+description: Runs build
+
+runs:
+  using: "composite"
+  steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.19.x
+          registry-url: https://registry.npmjs.org
+      - name: Install Yarn
+        run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
+      - name: Install packages
+        run: yarn install --frozen-lockfile
+      - name: Run build
+        run: yarn run build
+      - name: Run unit tests
+        run: yarn run test

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -10,8 +10,11 @@ runs:
         node-version: 18.19.x
         registry-url: https://registry.npmjs.org
     - name: Install Yarn
+      shell: bash
       run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
     - name: Install packages
+      shell: bash
       run: yarn install --frozen-lockfile
     - name: Run lint
+      shell: bash
       run: yarn run lint

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: 18.19.x
+        node-version: 18.x
         registry-url: https://registry.npmjs.org
     - name: Install Yarn
       shell: bash

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -4,8 +4,6 @@ description: Runs lint
 runs:
   using: "composite"
   steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v4
     - name: Setup Node
       uses: actions/setup-node@v4
       with:

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -1,0 +1,19 @@
+name: Lint
+description: Runs lint
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v4
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18.19.x
+        registry-url: https://registry.npmjs.org
+    - name: Install Yarn
+      run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
+    - name: Install packages
+      run: yarn install --frozen-lockfile
+    - name: Run lint
+      run: yarn run lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,26 +13,33 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18.19.x
-          registry-url: https://registry.npmjs.org
-      - name: Install Yarn
-        run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
-      - name: Install packages
-        run: yarn install
-      - name: Run lint
-        run: yarn run lint
+      - name: lint
+        uses: ./.github/actions/lint
+
   build:
     name: Build and Test
     runs-on: ubuntu-latest
-    concurrency: build-and-test # Currently integration tests can clash across branches.
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+      - name: build
+        uses: ./.github/actions/build
+
+  test:
+    # Only run tests on the schedule event
+    # On 'push' we've just merged a PR that ran the tests
+    if: github.event_name == 'schedule'
+    name: acceptance-test
+    concurrency:
+      group: acceptance-test-${{ matrix.index }} # TODO: concurrent tests across PRs can cause problems
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      # Needed for pulumictl to calculate version
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.11.0
         with:
@@ -46,44 +53,83 @@ jobs:
           role-duration-seconds: 3600
           role-session-name: ${{ env.PROVIDER }}@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.19.x
+          node-version: 18.x
           registry-url: https://registry.npmjs.org
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.22.x
+          cache-dependency-path: examples/*.sum
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
       - name: Install packages
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Run build
-        run: yarn run build
-      - name: Run unit tests
-        run: yarn run test
+        run: yarn run prepare && yarn run build
       - name: yarn link
-        run: pushd lib && yarn link && popd
+        run: yarn link
       - name: set script-shell
         run: yarn config set script-shell /bin/bash
-      - name: Set up gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+      - name: Go mod download
+        run: cd examples && go mod download
+      - name: Generate go test Slice
+        id: test_split
+        uses: hashicorp-forge/go-test-split-action@v2.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: examples
+          total: ${{ matrix.parallel }}
+          index: ${{ matrix.index }}
       - name: Run examples
-        run: yarn run test-examples-gotestfmt
+        run: cd examples && gotestsum --format github-actions -- -v -count=1 -timeout 2h -parallel 4 -run "${{ steps.test_split.outputs.run }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        parallel: [3]
+        index: [0, 1, 2]
+
+  release:
+    if: github.event_name == 'push'
+    name: Release
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - lint
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      # Needed for pulumictl to calculate version
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.11.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          registry-url: https://registry.npmjs.org
+      - name: Install Yarn
+        run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
+      - name: Install packages
+        run: yarn install --frozen-lockfile
+      - name: Run build
+        run: yarn run set-version && yarn run build
       - if: github.event_name == 'push'
         name: Publish Dev Package
         uses: JS-DevTools/npm-publish@v1
         with:
           access: "public"
           token: ${{ secrets.NPM_TOKEN }}
-          package: ${{github.workspace}}/lib/package.json
+          package: ${{github.workspace}}/package.json
           tag: dev
           check-version: true
+
 name: main
 "on":
   schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        uses: jaxxstorm/action-install-gh-release@v1.11.0
         with:
           repo: pulumi/pulumictl
       - name: Configure AWS Credentials
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.19.x
+          node-version: 18.x
           registry-url: https://registry.npmjs.org
       - name: Install Go
         uses: actions/setup-go@v5
@@ -90,7 +90,7 @@ jobs:
         index: [0, 1, 2]
 
   release:
-    name: Build and Test
+    name: Release
     runs-on: ubuntu-latest
     needs:
       - build
@@ -106,12 +106,10 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.11.0
         with:
           repo: pulumi/pulumictl
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.19.x
+          node-version: 18.x
           registry-url: https://registry.npmjs.org
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Install packages
         run: yarn install --frozen-lockfile
       - name: Run build
-        run: yarn run prepare && yarn run build
+        run: yarn run set-version && yarn run build
       - name: Publish Dev Package
         uses: JS-DevTools/npm-publish@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+      # Needed for pulumictl to calculate version
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:
@@ -96,6 +99,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+      # Needed for pulumictl to calculate version
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.11.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     name: Run lint
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
       - name: lint
         uses: ./.github/actions/lint
 
@@ -18,6 +20,8 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
       - name: build
         uses: ./.github/actions/build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,30 +11,27 @@ jobs:
     name: Run lint
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18.19.x
-          registry-url: https://registry.npmjs.org
-      - name: Install Yarn
-        run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
-      - name: Install packages
-        run: yarn install
-      - name: Run lint
-        run: yarn run lint
+      - name: lint
+        uses: ./.github/actions/lint
+
   build:
     name: Build and Test
     runs-on: ubuntu-latest
-    concurrency: build-and-test # Currently integration tests can clash across branches.
+    steps:
+      - name: build
+        uses: ./.github/actions/build
+
+  test:
+    name: acceptance-test
+    concurrency:
+      group: acceptance-test-${{ matrix.index }} # TODO: concurrent tests across PRs can cause problems
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.11.0
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:
           repo: pulumi/pulumictl
       - name: Configure AWS Credentials
@@ -46,8 +43,6 @@ jobs:
           role-duration-seconds: 3600
           role-session-name: ${{ env.PROVIDER }}@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -57,30 +52,69 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.22.x
+          cache-dependency-path: examples/*.sum
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
       - name: Install packages
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Run build
-        run: yarn run build
-      - name: Run unit tests
-        run: yarn run test
+        run: yarn run prepare && yarn run build
       - name: yarn link
-        run: pushd lib && yarn link && popd
+        run: yarn link
       - name: set script-shell
         run: yarn config set script-shell /bin/bash
-      - name: Set up gotestfmt
-        uses: haveyoudebuggedit/gotestfmt-action@v2
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+      - name: Go mod download
+        run: cd examples && go mod download
+      - name: Generate go test Slice
+        id: test_split
+        uses: hashicorp-forge/go-test-split-action@v2.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: examples
+          total: ${{ matrix.parallel }}
+          index: ${{ matrix.index }}
       - name: Run examples
-        run: yarn run test-examples-gotestfmt
+        run: cd examples && gotestsum --format github-actions -- -v -count=1 -timeout 2h -parallel 4 -run "${{ steps.test_split.outputs.run }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        parallel: [3]
+        index: [0, 1, 2]
+
+  release:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test
+      - lint
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.11.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.19.x
+          registry-url: https://registry.npmjs.org
+      - name: Install Yarn
+        run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
+      - name: Install packages
+        run: yarn install --frozen-lockfile
+      - name: Run build
+        run: yarn run prepare && yarn run build
       - name: Publish Dev Package
         uses: JS-DevTools/npm-publish@v1
         with:
           access: "public"
           token: ${{ secrets.NPM_TOKEN }}
-          package: ${{github.workspace}}/lib/package.json
+          package: ${{github.workspace}}/package.json
 name: release
 "on":
   push:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -27,28 +27,29 @@ jobs:
     name: Run lint
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18.19.x
-          registry-url: https://registry.npmjs.org
-      - name: Install Yarn
-        run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
-      - name: Install packages
-        run: yarn install
-      - name: Run lint
-        run: yarn run lint
+      - name: lint
+        uses: ./.github/actions/lint
+
   build:
     name: Build and Test
     runs-on: ubuntu-latest
-    concurrency: build-and-test # Currently integration tests can clash across branches.
+    steps:
+      - name: build
+        uses: ./.github/actions/build
+
+  test:
+    name: acceptance-test
+    concurrency:
+      group: acceptance-test-${{ matrix.index }} # TODO: concurrent tests across PRs can cause problems
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        with:
+          repo: pulumi/pulumictl
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -58,8 +59,6 @@ jobs:
           role-duration-seconds: 3600
           role-session-name: ${{ env.PROVIDER }}@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -69,24 +68,36 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.22.x
+          cache-dependency-path: examples/*.sum
       - name: Install Yarn
         run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
       - name: Install packages
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Run build
-        run: yarn run build
-      - name: Run unit tests
-        run: yarn run test
+        run: yarn run prepare && yarn run build
       - name: yarn link
-        run: pushd lib && yarn link && popd
+        run: yarn link
       - name: set script-shell
         run: yarn config set script-shell /bin/bash
-      - name: Set up gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+      - name: Go mod download
+        run: cd examples && go mod download
+      - name: Generate go test Slice
+        id: test_split
+        uses: hashicorp-forge/go-test-split-action@v2.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: examples
+          total: ${{ matrix.parallel }}
+          index: ${{ matrix.index }}
       - name: Run examples
-        run: yarn run test-examples-gotestfmt
+        run: cd examples && gotestsum --format github-actions -- -v -count=1 -timeout 2h -parallel 4 -run "${{ steps.test_split.outputs.run }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        parallel: [3]
+        index: [0, 1, 2]
+
 name: Run Acceptance Tests from PR
 on:
   repository_dispatch:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -50,6 +50,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+      # Needed for pulumictl to calculate version
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Install packages
         run: yarn install --frozen-lockfile
       - name: Run build
-        run: yarn run prepare && yarn run build
+        run: yarn run set-version && yarn run build
       - name: yarn link
         run: yarn link
       - name: set script-shell

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        uses: jaxxstorm/action-install-gh-release@v1.11.0
         with:
           repo: pulumi/pulumictl
       - name: Configure AWS Credentials
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.19.x
+          node-version: 18.x
           registry-url: https://registry.npmjs.org
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -27,6 +27,8 @@ jobs:
     name: Run lint
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
       - name: lint
         uses: ./.github/actions/lint
 
@@ -34,6 +36,8 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
       - name: build
         uses: ./.github/actions/build
 

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+/examples/
+/tests/
+/src/
+/coverage/
+/.github/
+/.eslintignore
+/.eslintrc.js
+/test-reports/
+/.prettierrc
+tsconfig.json
+!/lib/
+!/lib/**/*.js
+!/lib/**/*.d.ts
+

--- a/examples/alb/index.ts
+++ b/examples/alb/index.ts
@@ -3,8 +3,6 @@ import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import * as pulumi from '@pulumi/pulumi';
 import * as pulumicdk from '@pulumi/cdk';
-import * as aws from '@pulumi/aws';
-import { Construct } from 'constructs';
 
 class AlbStack extends pulumicdk.Stack {
     url: pulumi.Output<string>;

--- a/examples/alb/package.json
+++ b/examples/alb/package.json
@@ -5,12 +5,10 @@
     },
     "dependencies": {
         "@pulumi/aws": "^4.6.0",
-        "@pulumi/aws-native": "^0.108.0",
+        "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "^2.20.0",
-        "constructs": "^10.0.111"
-    },
-    "peerDependencies": {
-        "@pulumi/cdk": "^0.0.1"
+        "constructs": "^10.0.111", 
+        "@pulumi/cdk": "^0.5.0"
     }
 }

--- a/examples/alb/package.json
+++ b/examples/alb/package.json
@@ -7,7 +7,7 @@
         "@pulumi/aws": "^4.6.0",
         "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
-        "aws-cdk-lib": "^2.20.0",
+        "aws-cdk-lib": "2.149.0",
         "constructs": "^10.0.111", 
         "@pulumi/cdk": "^0.5.0"
     }

--- a/examples/api-websocket-lambda-dynamodb/package.json
+++ b/examples/api-websocket-lambda-dynamodb/package.json
@@ -10,7 +10,7 @@
         "@pulumi/aws-native": "^0.117.0",
         "@pulumi/cdk": "^0.5.0",
         "@pulumi/pulumi": "^3.0.0",
-        "aws-cdk-lib": "^2.20.0",
+        "aws-cdk-lib": "2.149.0",
         "constructs": "^10.0.111"
     }
 }

--- a/examples/api-websocket-lambda-dynamodb/package.json
+++ b/examples/api-websocket-lambda-dynamodb/package.json
@@ -4,13 +4,13 @@
         "@types/node": "^10.0.0"
     },
     "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.632.0",
+        "@aws-sdk/lib-dynamodb": "^3.632.0",
         "@pulumi/aws": "^4.6.0",
-        "@pulumi/aws-native": "^0.108.0",
+        "@pulumi/aws-native": "^0.117.0",
+        "@pulumi/cdk": "^0.5.0",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "^2.20.0",
         "constructs": "^10.0.111"
-    },
-    "peerDependencies": {
-        "@pulumi/cdk": "^0.0.1"
     }
 }

--- a/examples/apprunner/package.json
+++ b/examples/apprunner/package.json
@@ -8,7 +8,7 @@
         "@pulumi/awsx": "^0.32.0",
         "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
-        "aws-cdk-lib": "^2.20.0",
+        "aws-cdk-lib": "2.149.0",
         "constructs": "^10.0.111",
         "@pulumi/cdk": "^0.5.0", 
         "@aws-cdk/aws-apprunner-alpha": "2.20.0-alpha.0"

--- a/examples/apprunner/package.json
+++ b/examples/apprunner/package.json
@@ -6,13 +6,11 @@
     "dependencies": {
         "@pulumi/aws": "^4.6.0",
         "@pulumi/awsx": "^0.32.0",
-        "@pulumi/aws-native": "^0.108.0",
+        "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "^2.20.0",
         "constructs": "^10.0.111",
+        "@pulumi/cdk": "^0.5.0", 
         "@aws-cdk/aws-apprunner-alpha": "2.20.0-alpha.0"
-    },
-    "peerDependencies": {
-        "@pulumi/cdk": "^0.0.1"
     }
 }

--- a/examples/appsvc/package.json
+++ b/examples/appsvc/package.json
@@ -5,12 +5,10 @@
     },
     "dependencies": {
         "@pulumi/aws": "^4.6.0",
-        "@pulumi/aws-native": "^0.108.0",
+        "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "^2.20.0",
-        "constructs": "^10.0.111"
-    },
-    "peerDependencies": {
-        "@pulumi/cdk": "^0.0.1"
-    }
+        "constructs": "^10.0.111", 
+        "@pulumi/cdk": "^0.5.0"
+    } 
 }

--- a/examples/appsvc/package.json
+++ b/examples/appsvc/package.json
@@ -7,7 +7,7 @@
         "@pulumi/aws": "^4.6.0",
         "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
-        "aws-cdk-lib": "^2.20.0",
+        "aws-cdk-lib": "2.149.0",
         "constructs": "^10.0.111", 
         "@pulumi/cdk": "^0.5.0"
     } 

--- a/examples/cron-lambda/index.ts
+++ b/examples/cron-lambda/index.ts
@@ -2,10 +2,9 @@ import * as fs from 'fs';
 import * as aws_events from 'aws-cdk-lib/aws-events';
 import * as aws_events_targets from 'aws-cdk-lib/aws-events-targets';
 import * as aws_lambda from 'aws-cdk-lib/aws-lambda';
-import { CfnOutput, Duration } from 'aws-cdk-lib';
+import { Duration } from 'aws-cdk-lib';
 import * as pulumi from '@pulumi/pulumi';
 import * as pulumicdk from '@pulumi/cdk';
-import { Construct } from 'constructs';
 import { remapCloudControlResource } from './adapter';
 
 class LambdaStack extends pulumicdk.Stack {

--- a/examples/cron-lambda/package.json
+++ b/examples/cron-lambda/package.json
@@ -8,7 +8,7 @@
         "@pulumi/awsx": "^0.32.0",
         "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
-        "aws-cdk-lib": "^2.20.0",
+        "aws-cdk-lib": "2.149.0",
         "constructs": "^10.0.111", 
         "@pulumi/cdk": "^0.5.0"
     } 

--- a/examples/cron-lambda/package.json
+++ b/examples/cron-lambda/package.json
@@ -6,12 +6,10 @@
     "dependencies": {
         "@pulumi/aws": "^4.6.0",
         "@pulumi/awsx": "^0.32.0",
-        "@pulumi/aws-native": "^0.108.0",
+        "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "^2.20.0",
-        "constructs": "^10.0.111"
-    },
-    "peerDependencies": {
-        "@pulumi/cdk": "^0.0.1"
-    }
+        "constructs": "^10.0.111", 
+        "@pulumi/cdk": "^0.5.0"
+    } 
 }

--- a/examples/ec2-instance/package.json
+++ b/examples/ec2-instance/package.json
@@ -5,12 +5,10 @@
     },
     "dependencies": {
         "@pulumi/aws": "^4.6.0",
-        "@pulumi/aws-native": "^0.108.0",
+        "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "^2.20.0",
-        "constructs": "^10.0.111"
-    },
-    "peerDependencies": {
-        "@pulumi/cdk": "^0.0.1"
-    }
+        "constructs": "^10.0.111", 
+        "@pulumi/cdk": "^0.5.0"
+    } 
 }

--- a/examples/ec2-instance/package.json
+++ b/examples/ec2-instance/package.json
@@ -7,7 +7,7 @@
         "@pulumi/aws": "^4.6.0",
         "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
-        "aws-cdk-lib": "^2.20.0",
+        "aws-cdk-lib": "2.149.0",
         "constructs": "^10.0.111", 
         "@pulumi/cdk": "^0.5.0"
     } 

--- a/examples/ecscluster/package.json
+++ b/examples/ecscluster/package.json
@@ -5,12 +5,10 @@
     },
     "dependencies": {
         "@pulumi/aws": "^4.6.0",
-        "@pulumi/aws-native": "^0.108.0",
+        "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "^2.20.0",
-        "constructs": "^10.0.111"
-    },
-    "peerDependencies": {
-        "@pulumi/cdk": "^0.0.1"
-    }
+        "constructs": "^10.0.111", 
+        "@pulumi/cdk": "^0.5.0"
+    } 
 }

--- a/examples/ecscluster/package.json
+++ b/examples/ecscluster/package.json
@@ -7,7 +7,7 @@
         "@pulumi/aws": "^4.6.0",
         "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
-        "aws-cdk-lib": "^2.20.0",
+        "aws-cdk-lib": "2.149.0",
         "constructs": "^10.0.111", 
         "@pulumi/cdk": "^0.5.0"
     } 

--- a/examples/fargate/package.json
+++ b/examples/fargate/package.json
@@ -5,12 +5,10 @@
     },
     "dependencies": {
         "@pulumi/aws": "^4.6.0",
-        "@pulumi/aws-native": "^0.108.0",
+        "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "^2.20.0",
-        "constructs": "^10.0.111"
-    },
-    "peerDependencies": {
-        "@pulumi/cdk": "^0.0.1"
+        "constructs": "^10.0.111", 
+        "@pulumi/cdk": "^0.5.0"
     }
 }

--- a/examples/fargate/package.json
+++ b/examples/fargate/package.json
@@ -7,7 +7,7 @@
         "@pulumi/aws": "^4.6.0",
         "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
-        "aws-cdk-lib": "^2.20.0",
+        "aws-cdk-lib": "2.149.0",
         "constructs": "^10.0.111", 
         "@pulumi/cdk": "^0.5.0"
     }

--- a/examples/s3-object-lambda/index.ts
+++ b/examples/s3-object-lambda/index.ts
@@ -1,4 +1,4 @@
-import { S3ObjectLambdaStack } from './lib/s3-object-lambda-stack';
+import { S3ObjectLambdaStack } from './src/s3-object-lambda-stack';
 
 const s = new S3ObjectLambdaStack('stack');
 export const exampleBucketArn = s.exampleBucketArn;

--- a/examples/s3-object-lambda/package.json
+++ b/examples/s3-object-lambda/package.json
@@ -4,7 +4,8 @@
         "@types/node": "^20.0.0"
     },
     "dependencies": {
-        "@pulumi/cdk": "^0.4",
+        "@pulumi/cdk": "^0.5.0",
+        "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "^2.20.0",
         "constructs": "^10.0.111"

--- a/examples/s3-object-lambda/package.json
+++ b/examples/s3-object-lambda/package.json
@@ -7,7 +7,7 @@
         "@pulumi/cdk": "^0.5.0",
         "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
-        "aws-cdk-lib": "^2.20.0",
+        "aws-cdk-lib": "2.149.0",
         "constructs": "^10.0.111"
     }
 }

--- a/examples/s3-object-lambda/src/s3-object-lambda-stack.ts
+++ b/examples/s3-object-lambda/src/s3-object-lambda-stack.ts
@@ -1,0 +1,116 @@
+import * as pulumi from '@pulumi/pulumi';
+import * as pulumicdk from '@pulumi/cdk';
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as s3ObjectLambda from 'aws-cdk-lib/aws-s3objectlambda';
+import { Construct } from 'constructs';
+
+// configurable variables
+const S3_ACCESS_POINT_NAME = 'example-test-ap';
+const OBJECT_LAMBDA_ACCESS_POINT_NAME = 's3-object-lambda-ap';
+
+export class S3ObjectLambdaStack extends pulumicdk.Stack {
+    exampleBucketArn: pulumi.Output<string>;
+    objectLambdaArn: pulumi.Output<string>;
+    objectLambdaAccessPointArn: pulumi.Output<string>;
+    objectLambdaAccessPointUrl: pulumi.Output<string>;
+
+    constructor(id: string) {
+        super(id);
+
+        const accessPoint = `arn:aws:s3:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:accesspoint/${S3_ACCESS_POINT_NAME}`;
+
+        // Set up a bucket
+        const bucket = new s3.Bucket(this, 'example-bucket', {
+            accessControl: s3.BucketAccessControl.BUCKET_OWNER_FULL_CONTROL,
+            encryption: s3.BucketEncryption.S3_MANAGED,
+            blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+        });
+
+        // Delegating access control to access points
+        // https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points-policies.html
+        bucket.addToResourcePolicy(
+            new iam.PolicyStatement({
+                actions: ['*'],
+                principals: [new iam.AnyPrincipal()],
+                resources: [bucket.bucketArn, bucket.arnForObjects('*')],
+                conditions: {
+                    StringEquals: {
+                        's3:DataAccessPointAccount': `${cdk.Aws.ACCOUNT_ID}`,
+                    },
+                },
+            }),
+        );
+
+        // lambda to process our objects during retrieval
+        const retrieveTransformedObjectLambda = new lambda.Function(this, 'retrieveTransformedObjectLambda', {
+            runtime: lambda.Runtime.NODEJS_20_X,
+            handler: 'index.handler',
+            code: lambda.Code.fromAsset('resources/retrieve-transformed-object-lambda'),
+            environment: {
+                KEY: 'Value',
+            },
+        });
+
+        // Object lambda s3 access
+        retrieveTransformedObjectLambda.addToRolePolicy(
+            new iam.PolicyStatement({
+                effect: iam.Effect.ALLOW,
+                resources: ['*'],
+                actions: ['s3-object-lambda:WriteGetObjectResponse'],
+            }),
+        );
+        // Restrict Lambda to be invoked from own account
+        retrieveTransformedObjectLambda.addPermission('invocationRestriction', {
+            action: 'lambda:InvokeFunction',
+            principal: new iam.AccountRootPrincipal(),
+            sourceAccount: cdk.Aws.ACCOUNT_ID,
+        });
+
+        // Associate Bucket's access point with lambda get access
+        const policyDoc = new iam.PolicyDocument();
+        const policyStatement = new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: ['s3:GetObject'],
+            principals: [new iam.ArnPrincipal(<string>retrieveTransformedObjectLambda.role?.roleArn)],
+            resources: [`${accessPoint}/object/*`],
+        });
+        policyStatement.sid = 'AllowLambdaToUseAccessPoint';
+        policyDoc.addStatements(policyStatement);
+
+        new s3.CfnAccessPoint(this, 'exampleBucketAP', {
+            bucket: bucket.bucketName,
+            name: S3_ACCESS_POINT_NAME,
+            policy: policyDoc,
+        });
+
+        // Access point to receive GET request and use lambda to process objects
+        const objectLambdaAP = new s3ObjectLambda.CfnAccessPoint(this, 's3ObjectLambdaAP', {
+            name: OBJECT_LAMBDA_ACCESS_POINT_NAME,
+            objectLambdaConfiguration: {
+                supportingAccessPoint: accessPoint,
+                transformationConfigurations: [
+                    {
+                        actions: ['GetObject'],
+                        contentTransformation: {
+                            AwsLambda: {
+                                FunctionArn: `${retrieveTransformedObjectLambda.functionArn}`,
+                            },
+                        },
+                    },
+                ],
+            },
+        });
+
+        this.exampleBucketArn = this.asOutput(bucket.bucketArn);
+        this.objectLambdaArn = this.asOutput(retrieveTransformedObjectLambda.functionArn);
+        this.objectLambdaAccessPointArn = this.asOutput(objectLambdaAP.attrArn);
+        this.objectLambdaAccessPointUrl = this.asOutput(
+            `https://console.aws.amazon.com/s3/olap/${cdk.Aws.ACCOUNT_ID}/${OBJECT_LAMBDA_ACCESS_POINT_NAME}?region=${cdk.Aws.REGION}`,
+        );
+
+        this.synth();
+    }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "git+https://github.com/pulumi/pulumi-cdk.git"
   },
   "license": "Apache-2.0",
+  "main": "lib/index.js",
   "bugs": {
     "url": "https://github.com/pulumi/pulumi-cdk/issues"
   },
@@ -57,16 +58,15 @@
     "archiver": "^7.0.1"
   },
   "scripts": {
-    "build": "tsc && cp package.json README.md LICENSE lib/ && sed -i.bak -e \"s/\\${VERSION}/$(pulumictl get version --language javascript)/g\" lib/package.json && rm lib/package.json.bak",
+    "prepare": "sed -i.bak -e \"s/\\${VERSION}/$(pulumictl get version --language javascript)/g\" package.json && rm package.json.bak",
+    "build": "tsc --build",
+    "watch": "tsc --build --watch",
     "lint": "./node_modules/.bin/eslint --ext .js,.jsx,.ts,.tsx --fix --no-error-on-unmatched-pattern src",
     "format": "./node_modules/.bin/prettier --write \"src/**/*.ts\" \"examples/**/*.ts\"",
     "test": "jest --passWithNoTests --updateSnapshot",
-    "test-examples": "cd lib && yarn link && cd .. && cd examples && go test -timeout 2h -v .",
-    "test-examples-gotestfmt": "cd lib && yarn link && cd .. && cd examples && set -euo pipefail && go test -json  -v -count=1 -cover -timeout 2h -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt"
+    "test:watch": "jest --watch",
+    "test-examples": "yarn link && cd examples && go test -timeout 2h -v ."
   },
-  "files": [
-    "*"
-  ],
   "jest": {
     "transform": {
       "^.+\\.ts$": [

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/archiver": "^6.0.2",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.12.13",
-    "aws-cdk-lib": "^2.20.0",
+    "aws-cdk-lib": "2.149.0",
     "constructs": "^10.0.111",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
@@ -58,7 +58,7 @@
     "archiver": "^7.0.1"
   },
   "scripts": {
-    "prepare": "sed -i.bak -e \"s/\\${VERSION}/$(pulumictl get version --language javascript)/g\" package.json && rm package.json.bak",
+    "set-version": "sed -i.bak -e \"s/\\${VERSION}/$(pulumictl get version --language javascript)/g\" package.json && rm package.json.bak",
     "build": "tsc --build",
     "watch": "tsc --build --watch",
     "lint": "./node_modules/.bin/eslint --ext .js,.jsx,.ts,.tsx --fix --no-error-on-unmatched-pattern src",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1620,7 +1620,7 @@ async@^3.2.3, async@^3.2.4:
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.5.tgz#ebd52a8fdaf7a2289a24df399f8d8485c8a46b66"
   integrity sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==
 
-aws-cdk-lib@^2.20.0:
+aws-cdk-lib@2.149.0:
   version "2.149.0"
   resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.149.0.tgz#5f13a6b2c222f6a1db66be6a58129a67845bf6e8"
   integrity sha512-bmbgnF2dEYlsZlVaNoSfcjyIUirnvmsvNXJwBMmUCZn2IZ+YWvkMv+rr4e/GO3gPKrdNzew1jNVvHSYxlun6rA==
@@ -4496,8 +4496,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  name strip-ansi-cjs
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4510,6 +4509,13 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -4835,7 +4841,16 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@7.0.0, wrap-ansi@^7.0.0, wrap-ansi@^8.1.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@7.0.0, wrap-ansi@^7.0.0, wrap-ansi@^8.1.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
This PR updates the workflows and scripts

**Workflows**
- Splits the acceptance tests to run in parallel across 3 workers
- Runs unit tests and acceptance tests in different jobs
- Applies the same changes to the release workflow
- Moves some reusable logic into actions/*/action.yml files

**Others**
- Replaced the `package.json` `files` config with `.npmignore`
- Instead of running npm publish from the `lib` directory, it is now run
  from the root directory (this is in preparation of #147 which needs
  non-lib files included)
- Separated out a `prepare` script from `build` so that build can be run
  locally without updating the `package.json` version field
- Added a `watch` and a `test:watch` script
- run `yarn link` from the root of the directory instead of `lib`
  - This also requires us to pin `aws-cdk-lib` version (devDep in root package.json, dep in examples) so that the version is the same between `@pulumi/cdk` and the examples. Different versions cause type errors.