### PR TITLE
Fix references to 'yarn run prepare'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install packages
         run: yarn install --frozen-lockfile
       - name: Run build
-        run: yarn run prepare && yarn run build
+        run: yarn run set-version && yarn run build
       - name: yarn link
         run: yarn link
       - name: set script-shell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install packages
         run: yarn install --frozen-lockfile
       - name: Run build
-        run: yarn run prepare && yarn run build
+        run: yarn run set-version && yarn run build
       - name: yarn link
         run: yarn link
       - name: set script-shell


### PR DESCRIPTION
There were some leftovers from refactoring done in #148. `yarn run prepare` should be `yarn run set-version` instead

Fixes #150