### PR TITLE
chore: cdk deps need to be the same for examples

### DIFF
--- a/examples/alb/package.json
+++ b/examples/alb/package.json
@@ -8,7 +8,7 @@
         "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "2.149.0",
-        "constructs": "^10.0.111", 
+        "constructs": "10.3.0",
         "@pulumi/cdk": "^0.5.0"
     }
 }

--- a/examples/api-websocket-lambda-dynamodb/package.json
+++ b/examples/api-websocket-lambda-dynamodb/package.json
@@ -12,6 +12,6 @@
         "@pulumi/cdk": "^0.5.0",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "2.149.0",
-        "constructs": "^10.0.111"
+        "constructs": "10.3.0" 
     }
 }

--- a/examples/apprunner/package.json
+++ b/examples/apprunner/package.json
@@ -9,7 +9,7 @@
         "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "2.149.0",
-        "constructs": "^10.0.111",
+        "constructs": "10.3.0",
         "@pulumi/cdk": "^0.5.0", 
         "@aws-cdk/aws-apprunner-alpha": "2.20.0-alpha.0"
     }

--- a/examples/appsvc/package.json
+++ b/examples/appsvc/package.json
@@ -8,7 +8,7 @@
         "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "2.149.0",
-        "constructs": "^10.0.111", 
+        "constructs": "10.3.0",
         "@pulumi/cdk": "^0.5.0"
     } 
 }

--- a/examples/cron-lambda/package.json
+++ b/examples/cron-lambda/package.json
@@ -9,7 +9,7 @@
         "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "2.149.0",
-        "constructs": "^10.0.111", 
+        "constructs": "10.3.0",
         "@pulumi/cdk": "^0.5.0"
     } 
 }

--- a/examples/ec2-instance/package.json
+++ b/examples/ec2-instance/package.json
@@ -8,7 +8,7 @@
         "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "2.149.0",
-        "constructs": "^10.0.111", 
+        "constructs": "10.3.0",
         "@pulumi/cdk": "^0.5.0"
     } 
 }

--- a/examples/ecscluster/package.json
+++ b/examples/ecscluster/package.json
@@ -8,7 +8,7 @@
         "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "2.149.0",
-        "constructs": "^10.0.111", 
+        "constructs": "10.3.0",
         "@pulumi/cdk": "^0.5.0"
     } 
 }

--- a/examples/fargate/package.json
+++ b/examples/fargate/package.json
@@ -8,7 +8,7 @@
         "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "2.149.0",
-        "constructs": "^10.0.111", 
+        "constructs": "10.3.0",
         "@pulumi/cdk": "^0.5.0"
     }
 }

--- a/examples/s3-object-lambda/package.json
+++ b/examples/s3-object-lambda/package.json
@@ -8,6 +8,6 @@
         "@pulumi/aws-native": "^0.117.0",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "2.149.0",
-        "constructs": "^10.0.111"
+        "constructs": "10.3.0" 
     }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/mock-fs": "^4.13.4",
     "@types/node": "^20.12.13",
     "aws-cdk-lib": "2.149.0",
-    "constructs": "^10.0.111",
+    "constructs": "10.3.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "jest": "^29.5.0",


### PR DESCRIPTION
CDK libraries have a weird requirement that only a single version of
`aws-cdk-lib` and `constructs` be installed. This means that the
`devDependency` in `package.json` and the dependencies in each
`examples` `package.json` needs to be the same. If they are different
versions then the examples will fail with `Argument of type 'this' is not assignable to parameter of type 'Construct'.`

fixes #175