### PR TITLE
Add another example and map additional resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,5 @@ dist
 
 test-reports/
 lib/
+
+**/cdk.out

--- a/examples/eventbridge-sns/Pulumi.yaml
+++ b/examples/eventbridge-sns/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-aws-eventbridge-sns
+runtime: nodejs
+description: Eventbridge SNS example for CDK

--- a/examples/eventbridge-sns/index.handler.ts
+++ b/examples/eventbridge-sns/index.handler.ts
@@ -1,0 +1,56 @@
+import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
+let client: EventBridgeClient;
+
+export const handler = async function (event, context) {
+    if (!client) {
+        client = new EventBridgeClient();
+    }
+
+    const eventBusName = process.env.BUS_NAME;
+    await client.send(
+        new PutEventsCommand({
+            Entries: [
+                {
+                    // Event envelope fields
+                    Source: 'custom.myATMapp',
+                    EventBusName: eventBusName,
+                    DetailType: 'transaction',
+                    Time: new Date(),
+                    // Main event body
+                    Detail: JSON.stringify({
+                        action: 'withdrawal',
+                        location: 'MA-BOS-01',
+                        amount: 300,
+                        result: 'approved',
+                        transactionId: '123456',
+                        cardPresent: true,
+                        partnerBank: 'Example Bank',
+                        remainingFunds: 722.34,
+                    }),
+                },
+                {
+                    // Event envelope fields
+                    Source: 'custom.myATMapp',
+                    EventBusName: eventBusName,
+                    DetailType: 'transaction',
+                    Time: new Date(),
+
+                    // Main event body
+                    Detail: JSON.stringify({
+                        action: 'withdrawal',
+                        location: 'NY-NYC-002',
+                        amount: 60,
+                        result: 'denied',
+                        transactionId: '123458',
+                        cardPresent: true,
+                        remainingFunds: 5.77,
+                    }),
+                },
+            ],
+        }),
+    );
+
+    return {
+        statusCode: 200,
+    };
+};

--- a/examples/eventbridge-sns/index.ts
+++ b/examples/eventbridge-sns/index.ts
@@ -1,0 +1,72 @@
+import * as pulumicdk from '@pulumi/cdk';
+import {
+    aws_events,
+    aws_events_targets,
+    aws_lambda,
+    aws_lambda_nodejs,
+    aws_sns,
+    aws_sns_subscriptions,
+    aws_sqs,
+} from 'aws-cdk-lib';
+
+class EventBridgeSnsStack extends pulumicdk.Stack {
+    constructor(id: string) {
+        super(id);
+
+        const eventBus = new aws_events.EventBus(this, 'Bus');
+        const handler = new aws_lambda_nodejs.NodejsFunction(this, 'handler', {
+            runtime: aws_lambda.Runtime.NODEJS_LATEST,
+            environment: {
+                BUS_NAME: eventBus.eventBusName,
+            },
+        });
+        eventBus.grantPutEventsTo(handler);
+
+        const approvedRule = new aws_events.Rule(this, 'approved-rule', {
+            eventBus,
+            description: 'Approved transactions',
+            eventPattern: {
+                source: ['custom.myATMapp'],
+                detailType: ['transaction'],
+                detail: {
+                    result: ['approved'],
+                },
+            },
+        });
+
+        const approvedTopic = new aws_sns.Topic(this, 'approved-topic');
+
+        approvedRule.addTarget(new aws_events_targets.SnsTopic(approvedTopic));
+
+        const approvedQueue = new aws_sqs.Queue(this, 'approved-queue');
+        approvedTopic.addSubscription(
+            new aws_sns_subscriptions.SqsSubscription(approvedQueue, {
+                rawMessageDelivery: true,
+            }),
+        );
+
+        const deniedRule = new aws_events.Rule(this, 'denied-rule', {
+            eventBus,
+            description: 'Denied transactions',
+            eventPattern: {
+                source: ['custom.myATMapp'],
+                detailType: ['transaction'],
+                detail: {
+                    result: ['denied'],
+                },
+            },
+        });
+        const deniedTopic = new aws_sns.Topic(this, 'denied-topic');
+        deniedRule.addTarget(new aws_events_targets.SnsTopic(deniedTopic));
+
+        const deniedQueue = new aws_sqs.Queue(this, 'denied-queue');
+        deniedTopic.addSubscription(
+            new aws_sns_subscriptions.SqsSubscription(deniedQueue, {
+                rawMessageDelivery: true,
+            }),
+        );
+        this.synth();
+    }
+}
+
+new EventBridgeSnsStack('eventbridge-sns-stack');

--- a/examples/eventbridge-sns/index.ts
+++ b/examples/eventbridge-sns/index.ts
@@ -22,6 +22,13 @@ class EventBridgeSnsStack extends pulumicdk.Stack {
         });
         eventBus.grantPutEventsTo(handler);
 
+        // create an archive so we can replay events later
+        eventBus.archive('archive', {
+            eventPattern: {
+                source: ['custom.myATMapp'],
+            },
+        });
+
         const approvedRule = new aws_events.Rule(this, 'approved-rule', {
             eventBus,
             description: 'Approved transactions',

--- a/examples/eventbridge-sns/package.json
+++ b/examples/eventbridge-sns/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "pulumi-aws-cdk",
+    "devDependencies": {
+        "@types/node": "^20.0.0"
+    },
+    "dependencies": {
+        "@aws-sdk/client-eventbridge": "^3.678.0",
+        "@pulumi/aws-native": "^1.0.0",
+        "@pulumi/cdk": "^0.5.0",
+        "@pulumi/pulumi": "^3.0.0",
+        "aws-cdk-lib": "2.149.0",
+        "constructs": "10.3.0",
+        "esbuild": "^0.24.0"
+    }
+}

--- a/examples/eventbridge-sns/tsconfig.json
+++ b/examples/eventbridge-sns/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -111,6 +111,15 @@ func TestCloudFront(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestEventBridgeSNS(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: filepath.Join(getCwd(t), "eventbridge-sns"),
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestAPIWebsocketLambdaDynamoDB(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{

--- a/src/cfn-resource-mappings.ts
+++ b/src/cfn-resource-mappings.ts
@@ -25,14 +25,14 @@ export function mapToCfnResource(
     typeName: string,
     rawProps: any,
     options: pulumi.ResourceOptions,
-): ResourceMapping {
+): ResourceMapping[] {
     const props = normalize(rawProps, typeName);
     debug(`mapToCfnResource typeName: ${typeName} props: ${JSON.stringify(props)}`);
     switch (typeName) {
         case 'AWS::S3::Bucket':
             // Lowercase the bucket name to comply with the Bucket resource's naming constraints, which only allow
             // lowercase letters.
-            return new s3.Bucket(logicalId.toLowerCase(), props, options);
+            return [new s3.Bucket(logicalId.toLowerCase(), props, options)];
         default: {
             // When creating a generic `CfnResource` we don't have any information on the
             // attributes attached to the resource. We need to populate them by looking up the
@@ -41,7 +41,7 @@ export function mapToCfnResource(
             const resource = metadata.findResource(typeName);
             const attributes = Object.keys(resource.outputs);
 
-            return new CfnResource(logicalId, typeName, props, attributes, options);
+            return [new CfnResource(logicalId, typeName, props, attributes, options)];
         }
     }
 }

--- a/src/converters/app-converter.ts
+++ b/src/converters/app-converter.ts
@@ -112,10 +112,12 @@ export class StackConverter extends ArtifactConverter {
                 const options = this.processOptions(cfn, parent);
 
                 const mapped = this.mapResource(n.logicalId, cfn.Type, props, options);
-                const resource = pulumi.Resource.isInstance(mapped) ? mapped : mapped.resource;
-                const attributes = pulumi.Resource.isInstance(mapped) ? undefined : mapped.attributes;
-                this.resources.set(n.logicalId, { resource, attributes, resourceType: cfn.Type });
-                this.constructs.set(n.construct, resource);
+                mapped.forEach((m) => {
+                    const resource = pulumi.Resource.isInstance(m) ? m : m.resource;
+                    const attributes = pulumi.Resource.isInstance(m) ? undefined : m.attributes;
+                    this.resources.set(n.logicalId!, { resource, attributes, resourceType: cfn.Type });
+                    this.constructs.set(n.construct, resource);
+                });
 
                 debug(`Done creating resource for ${n.logicalId}`);
                 // TODO: process template conditions
@@ -186,7 +188,7 @@ export class StackConverter extends ArtifactConverter {
         typeName: string,
         props: any,
         options: pulumi.ResourceOptions,
-    ): ResourceMapping {
+    ): ResourceMapping[] {
         if (this.stackComponent.options?.remapCloudControlResource !== undefined) {
             const res = this.stackComponent.options.remapCloudControlResource(logicalId, typeName, props, options);
             if (res !== undefined) {

--- a/src/pulumi-metadata.ts
+++ b/src/pulumi-metadata.ts
@@ -7,8 +7,8 @@ import { PulumiProvider } from './types';
 import { debug } from '@pulumi/pulumi/log';
 
 export class UnknownCfnType extends Error {
-    constructor() {
-        super("CfnType doesn't exist as a native type");
+    constructor(cfnType: string) {
+        super(`CfnType ${cfnType} doesn't exist as a native type`);
     }
 }
 
@@ -35,7 +35,7 @@ export class Metadata {
         if (pType in this.pulumiMetadata.resources) {
             return this.pulumiMetadata.resources[pType];
         }
-        throw new UnknownCfnType();
+        throw new UnknownCfnType(cfnType);
     }
 
     public types(): { [key: string]: PulumiType } {

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export interface StackOptions extends pulumi.ComponentResourceOptions {
         typeName: string,
         props: any,
         options: pulumi.ResourceOptions,
-    ): ResourceMapping | undefined;
+    ): ResourceMapping[] | undefined;
 }
 
 /**

--- a/tests/aws-resource-mappings.test.ts
+++ b/tests/aws-resource-mappings.test.ts
@@ -9,6 +9,16 @@ jest.mock('@pulumi/aws', () => {
                 return {};
             }),
         },
+        sqs: {
+            QueuePolicy: jest.fn().mockImplementation(() => {
+                return {};
+            }),
+        },
+        sns: {
+            TopicPolicy: jest.fn().mockImplementation(() => {
+                return {};
+            }),
+        },
         iam: {
             Policy: jest.fn().mockImplementation(() => {
                 return {};
@@ -96,6 +106,122 @@ describe('AWS Resource Mappings', () => {
             {},
         );
     });
+
+    test('maps sns.TopicPolicy', () => {
+        // GIVEN
+        const cfnType = 'AWS::SNS::TopicPolicy';
+        const logicalId = 'my-resource';
+        const cfnProps = {
+            PolicyDocument: {
+                Version: '2012-10-17',
+                Statement: [
+                    {
+                        Effect: 'Allow',
+                        Action: ['sns:*'],
+                        Resource: '*',
+                    },
+                ],
+            },
+            Topics: ['my-topic', 'my-other-topic'],
+        };
+
+        // WHEN
+        mapToAwsResource(logicalId, cfnType, cfnProps, {});
+
+        // THEN
+        expect(aws.sns.TopicPolicy).toHaveBeenCalledTimes(2);
+        expect(aws.sns.TopicPolicy).toHaveBeenCalledWith(
+            logicalId,
+            expect.objectContaining({
+                arn: 'my-topic',
+                policy: {
+                    Version: '2012-10-17',
+                    Statement: [
+                        {
+                            Effect: 'Allow',
+                            Action: ['sns:*'],
+                            Resource: '*',
+                        },
+                    ],
+                },
+            }),
+        );
+        expect(aws.sns.TopicPolicy).toHaveBeenCalledWith(
+            logicalId,
+            expect.objectContaining({
+                arn: 'my-other-topic',
+                policy: {
+                    Version: '2012-10-17',
+                    Statement: [
+                        {
+                            Effect: 'Allow',
+                            Action: ['sns:*'],
+                            Resource: '*',
+                        },
+                    ],
+                },
+            }),
+        );
+    });
+
+    test('maps sqs.QueuePolicy', () => {
+        // GIVEN
+        const cfnType = 'AWS::SQS::QueuePolicy';
+        const logicalId = 'my-resource';
+        const cfnProps = {
+            Queues: ['my-queue', 'my-other-queue'],
+            PolicyDocument: {
+                Version: '2012-10-17',
+                Statement: [
+                    {
+                        Effect: 'Allow',
+                        Action: ['sqs:*'],
+                        Resource: '*',
+                    },
+                ],
+            },
+        };
+
+        // WHEN
+        mapToAwsResource(logicalId, cfnType, cfnProps, {});
+
+        // THEN
+        expect(aws.sqs.QueuePolicy).toHaveBeenCalledTimes(2);
+        expect(aws.sqs.QueuePolicy).toHaveBeenCalledWith(
+            logicalId,
+            expect.objectContaining({
+                queueUrl: 'my-queue',
+                policy: {
+                    Version: '2012-10-17',
+                    Statement: [
+                        {
+                            Effect: 'Allow',
+                            Action: ['sqs:*'],
+                            Resource: '*',
+                        },
+                    ],
+                },
+            }),
+        );
+
+        expect(aws.sqs.QueuePolicy).toHaveBeenCalledWith(
+            logicalId,
+            expect.objectContaining({
+                queueUrl: 'my-other-queue',
+                policy: {
+                    Version: '2012-10-17',
+                    Statement: [
+                        {
+                            Effect: 'Allow',
+                            Action: ['sqs:*'],
+                            Resource: '*',
+                        },
+                    ],
+                },
+            }),
+        );
+    });
+
     test('maps apigatewayv2.Integration', () => {
         // GIVEN
         const cfnType = 'AWS::ApiGatewayV2::Integration';


### PR DESCRIPTION
Adds tests for additional resources and adds mappings for very common
resources that do not yet have CCAPI support.

- AWS::SQS::QueuePolicy
- AWS::SNS::TopicPolicy

```
aws-native:sns:Subscription
aws-native:sqs:Queue
aws-native:sns:Topic
aws-native:sns:Subscription
aws-native:iam:Role
aws-native:lambda:Function
aws-native:events:EventBus
aws-native:events:Rule
aws-native:sns:Topic
```