### PR TITLE
Ignore direnv and Emacs files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,9 @@ lib/
 
 **/cdk.out
 **/cdk.context.json
+
+# direnv
+.envrc
+
+# Emacs
+.dir-locals.el


### PR DESCRIPTION
So that contributors can customize direnv and Emacs settings without checking them into the repository accidentally.