### PR TITLE
Fix IPV6 cidr blocks

### DIFF
--- a/integration/ec2/Pulumi.yaml
+++ b/integration/ec2/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-aws-ec2
+runtime: nodejs
+description: ec2 integration test

--- a/integration/ec2/index.ts
+++ b/integration/ec2/index.ts
@@ -1,0 +1,127 @@
+import * as aws from '@pulumi/aws';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import * as pulumicdk from '@pulumi/cdk';
+import { SecretValue } from 'aws-cdk-lib/core';
+
+class Ec2Stack extends pulumicdk.Stack {
+    constructor(app: pulumicdk.App, id: string, options?: pulumicdk.StackOptions) {
+        super(app, id, options);
+        const vpc = new ec2.Vpc(this, 'Vpc', {
+            maxAzs: 2,
+            ipProtocol: ec2.IpProtocol.DUAL_STACK,
+            vpnGateway: true,
+            ipAddresses: ec2.IpAddresses.cidr('10.0.0.0/16'),
+            natGateways: 1,
+            vpnConnections: {
+                dynamic: {
+                    ip: '1.2.3.4',
+                    tunnelOptions: [
+                        {
+                            preSharedKeySecret: SecretValue.unsafePlainText('secretkey1234'),
+                        },
+                        {
+                            preSharedKeySecret: SecretValue.unsafePlainText('secretkey5678'),
+                        },
+                    ],
+                },
+                static: {
+                    ip: '4.5.6.7',
+                    staticRoutes: ['192.168.10.0/24', '192.168.20.0/24'],
+                },
+            },
+            subnetConfiguration: [
+                {
+                    name: 'Public',
+                    subnetType: ec2.SubnetType.PUBLIC,
+                },
+                {
+                    name: 'Private',
+                    subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+                },
+                {
+                    name: 'Isolated',
+                    subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
+                },
+            ],
+            restrictDefaultSecurityGroup: false,
+        });
+
+        vpc.addFlowLog('FlowLogs', {
+            destination: ec2.FlowLogDestination.toCloudWatchLogs(),
+        });
+
+        vpc.addGatewayEndpoint('Dynamo', {
+            service: ec2.GatewayVpcEndpointAwsService.DYNAMODB,
+        });
+        vpc.addInterfaceEndpoint('ecr', {
+            service: ec2.InterfaceVpcEndpointAwsService.ECR_DOCKER,
+        });
+
+        new ec2.PrefixList(this, 'PrefixList', {});
+        const nacl = new ec2.NetworkAcl(this, 'NetworkAcl', {
+            vpc,
+            subnetSelection: { subnetType: ec2.SubnetType.PUBLIC },
+        });
+        nacl.addEntry('AllowAll', {
+            cidr: ec2.AclCidr.anyIpv4(),
+            ruleAction: ec2.Action.ALLOW,
+            ruleNumber: 100,
+            traffic: ec2.AclTraffic.allTraffic(),
+        });
+        new ec2.KeyPair(this, 'KeyPair');
+
+        const nlb = new elbv2.NetworkLoadBalancer(this, 'NLB1', { vpc });
+        new ec2.VpcEndpointService(this, 'EndpointService', {
+            vpcEndpointServiceLoadBalancers: [nlb],
+            allowedPrincipals: [new iam.ArnPrincipal('ec2.amazonaws.com')],
+        });
+    }
+}
+
+new pulumicdk.App(
+    'app',
+    (scope: pulumicdk.App) => {
+        new Ec2Stack(scope, 'teststack');
+    },
+    {
+        appOptions: {
+            remapCloudControlResource: (logicalId, typeName, props, options) => {
+                if (typeName === 'AWS::EC2::VPNGatewayRoutePropagation') {
+                    const tableIds: string[] = props.RouteTableIds;
+                    return tableIds.flatMap((tableId, i) => {
+                        const id = i === 0 ? logicalId : `${logicalId}-${i}`;
+                        return {
+                            logicalId: id,
+                            resource: new aws.ec2.VpnGatewayRoutePropagation(
+                                id,
+                                {
+                                    routeTableId: tableId,
+                                    vpnGatewayId: props.VpnGatewayId,
+                                },
+                                options,
+                            ),
+                        };
+                    });
+                }
+                if (typeName === 'AWS::EC2::NetworkAclEntry') {
+                    return new aws.ec2.NetworkAclRule(logicalId, {
+                        egress: props.Egress,
+                        toPort: props.PortRange?.To,
+                        fromPort: props.PortRange?.From,
+                        protocol: props.Protocol,
+                        ruleNumber: props.RuleNumber,
+                        networkAclId: props.NetworkAclId,
+                        ruleAction: props.RuleAction,
+                        cidrBlock: props.CidrBlock,
+                        ipv6CidrBlock: props.Ipv6CidrBlock,
+                        icmpCode: props.Icmp?.Code,
+                        icmpType: props.Icmp?.Type,
+                    });
+                }
+                return undefined;
+            },
+        },
+    },
+);

--- a/integration/ec2/package.json
+++ b/integration/ec2/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^6.0.0",
-        "@pulumi/aws-native": "^1.5.0",
+        "@pulumi/aws-native": "^1.6.0",
         "@pulumi/cdk": "^0.5.0",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "2.149.0",

--- a/integration/ec2/package.json
+++ b/integration/ec2/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "pulumi-aws-cdk",
+    "devDependencies": {
+        "@types/node": "^10.0.0"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/aws-native": "^1.5.0",
+        "@pulumi/cdk": "^0.5.0",
+        "@pulumi/pulumi": "^3.0.0",
+        "aws-cdk-lib": "2.149.0",
+        "constructs": "10.3.0",
+        "esbuild": "^0.24.0"
+    }
+}

--- a/integration/ec2/tsconfig.json
+++ b/integration/ec2/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2019",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "include": [
+        "./*.ts"
+    ]
+}

--- a/integration/examples_nodejs_test.go
+++ b/integration/examples_nodejs_test.go
@@ -41,6 +41,15 @@ func TestApiGatewayDomain(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestEc2(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: filepath.Join(getCwd(t), "ec2"),
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	base := getBaseOptions(t)
 	baseJS := base.With(integration.ProgramTestOptions{

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@aws-cdk/aws-apprunner-alpha": "2.20.0-alpha.0",
     "@pulumi/aws": "^6.32.0",
-    "@pulumi/aws-native": "^1.0.0",
+    "@pulumi/aws-native": "^1.5.0",
     "@pulumi/docker": "^4.5.0",
     "@pulumi/pulumi": "3.121.0",
     "@types/archiver": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@aws-cdk/aws-apprunner-alpha": "2.20.0-alpha.0",
     "@pulumi/aws": "^6.32.0",
-    "@pulumi/aws-native": "^1.5.0",
+    "@pulumi/aws-native": "^1.6.0",
     "@pulumi/docker": "^4.5.0",
     "@pulumi/pulumi": "3.121.0",
     "@types/archiver": "^6.0.2",

--- a/tests/converters/app-converter.test.ts
+++ b/tests/converters/app-converter.test.ts
@@ -322,7 +322,7 @@ describe('Stack Converter', () => {
                     cidr: {
                         Type: 'AWS::EC2::VPCCidrBlock',
                         Properties: {
-                            Ipv6AddressAttribute: 'cidr_ipv6AddressAttribute',
+                            Ipv6CidrBlock: 'cidr_ipv6AddressAttribute',
                         },
                     },
                     other: {

--- a/tests/graph.test.ts
+++ b/tests/graph.test.ts
@@ -304,7 +304,7 @@ test('vpc with ipv6 cidr block', () => {
 
     // The other resource should have it's edge swapped to the cidr resource
     expect(Array.from(nodes[2].incomingEdges.values())[0].logicalId).toEqual('other');
-    expect(Array.from(nodes[3].outgoingEdges.values())[0].logicalId).toEqual('cidr');
+    expect(Array.from(nodes[3].outgoingEdges.values())[1].logicalId).toEqual('cidr');
 });
 
 test('pulumi resource type name fallsback when fqn not available', () => {

--- a/tests/graph.test.ts
+++ b/tests/graph.test.ts
@@ -17,7 +17,7 @@ import { StackManifest } from '../src/assembly';
 import { createStackManifest } from './utils';
 
 describe('GraphBuilder', () => {
-    const nodes = new GraphBuilder(
+    const nodes = GraphBuilder.build(
         new StackManifest({
             id: 'stack',
             templatePath: 'test/stack',
@@ -95,7 +95,7 @@ describe('GraphBuilder', () => {
             },
             dependencies: [],
         }),
-    ).build();
+    );
     test.each([
         [
             nodes,
@@ -188,7 +188,7 @@ describe('GraphBuilder', () => {
             },
         ],
     ])('Parses the graph correctly', (graph, path, expected) => {
-        const actual = graph.find((node) => node.construct.path === path);
+        const actual = graph.nodes.find((node) => node.construct.path === path);
         expect(actual).toBeDefined();
         expect(actual!.logicalId).toEqual(expected.logicalId);
         expect(actual!.resource).toEqual(expected.resource);
@@ -225,7 +225,7 @@ describe('GraphBuilder', () => {
             }),
         ],
     ])('adds edge for %s', (_name, stackManifest) => {
-        const graph = new GraphBuilder(stackManifest).build();
+        const graph = GraphBuilder.build(stackManifest).nodes;
         expect(graph[1].construct.path).toEqual('stack/resource-1');
         expect(edgesToArray(graph[1].incomingEdges)).toEqual(['stack/resource-2']);
         expect(edgesToArray(graph[1].outgoingEdges)).toEqual(['stack']);
@@ -234,8 +234,9 @@ describe('GraphBuilder', () => {
         expect(edgesToArray(graph[2].outgoingEdges)).toEqual(['stack', 'stack/resource-1']);
     });
 });
+
 test('vpc with ipv6 cidr block', () => {
-    const nodes = new GraphBuilder(
+    const nodes = GraphBuilder.build(
         new StackManifest({
             id: 'stack',
             templatePath: 'test/stack',
@@ -283,7 +284,9 @@ test('vpc with ipv6 cidr block', () => {
                     },
                     cidr: {
                         Type: 'AWS::EC2::VPCCidrBlock',
-                        Properties: {},
+                        Properties: {
+                            VpcId: { Ref: 'vpc' },
+                        },
                     },
                     other: {
                         Type: 'AWS::Other::Resource',
@@ -295,7 +298,7 @@ test('vpc with ipv6 cidr block', () => {
             },
             dependencies: [],
         }),
-    ).build();
+    ).nodes;
     expect(nodes[0].construct.type).toEqual('aws-cdk-lib:Stack');
     expect(nodes[1].construct.type).toEqual('VPC');
     expect(nodes[2].construct.type).toEqual('VPCCidrBlock');
@@ -307,10 +310,92 @@ test('vpc with ipv6 cidr block', () => {
     expect(Array.from(nodes[3].outgoingEdges.values())[1].logicalId).toEqual('cidr');
 });
 
+test('vpc with multiple ipv6 cidr blocks fails', () => {
+    expect(() => {
+        GraphBuilder.build(
+            new StackManifest({
+                id: 'stack',
+                templatePath: 'test/stack',
+                metadata: {
+                    'stack/vpc': 'vpc',
+                    'stack/cidr': 'cidr',
+                    'stack/cidr2': 'cidr2',
+                    'stack/other': 'other',
+                },
+                tree: {
+                    path: 'stack',
+                    id: 'stack',
+                    children: {
+                        vpc: {
+                            id: 'vpc',
+                            path: 'stack/vpc',
+                            attributes: {
+                                'aws:cdk:cloudformation:type': 'AWS::EC2::VPC',
+                            },
+                        },
+                        cidr: {
+                            id: 'cidr',
+                            path: 'stack/cidr',
+                            attributes: {
+                                'aws:cdk:cloudformation:type': 'AWS::EC2::VPCCidrBlock',
+                            },
+                        },
+                        cidr2: {
+                            id: 'cidr2',
+                            path: 'stack/cidr2',
+                            attributes: {
+                                'aws:cdk:cloudformation:type': 'AWS::EC2::VPCCidrBlock',
+                            },
+                        },
+                        other: {
+                            id: 'other',
+                            path: 'stack/other',
+                            attributes: {
+                                'aws:cdk:cloudformation:type': 'AWS::Other::Resource',
+                            },
+                        },
+                    },
+                    constructInfo: {
+                        fqn: 'aws-cdk-lib.Stack',
+                        version: '2.149.0',
+                    },
+                },
+                template: {
+                    Resources: {
+                        vpc: {
+                            Type: 'AWS::EC2::VPC',
+                            Properties: {},
+                        },
+                        cidr: {
+                            Type: 'AWS::EC2::VPCCidrBlock',
+                            Properties: {
+                                VpcId: { Ref: 'vpc' },
+                            },
+                        },
+                        cidr2: {
+                            Type: 'AWS::EC2::VPCCidrBlock',
+                            Properties: {
+                                VpcId: { Ref: 'vpc' },
+                            },
+                        },
+                        other: {
+                            Type: 'AWS::Other::Resource',
+                            Properties: {
+                                SomeProp: { 'Fn::Select': [0, { 'Fn::GetAtt': ['vpc', 'Ipv6CidrBlocks'] }] },
+                            },
+                        },
+                    },
+                },
+                dependencies: [],
+            }),
+        ).nodes;
+    }).toThrow(/VPC vpc already has a VPCCidrBlock/);
+});
+
 test('pulumi resource type name fallsback when fqn not available', () => {
     const bucketId = 'example-bucket';
     const policyResourceId = 'Policy';
-    const nodes = new GraphBuilder(
+    const nodes = GraphBuilder.build(
         new StackManifest({
             id: 'stack',
             templatePath: 'test/stack',
@@ -380,7 +465,7 @@ test('pulumi resource type name fallsback when fqn not available', () => {
             },
             dependencies: [],
         }),
-    ).build();
+    ).nodes;
 
     expect(nodes[0].construct.type).toEqual('aws-cdk-lib:Stack');
     expect(nodes[1].construct.type).toEqual(bucketId);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,10 +1028,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@pulumi/aws-native@^1.0.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws-native/-/aws-native-1.3.0.tgz#10f654daa1cc578ab78a25ef614f888dd23e3276"
-  integrity sha512-egocWUmAmrRk+/LWof3yWdn+qrLy9rHUmrg5XjRP1SUo7pQgqEYMKY6IlV/81NV2zcdk6t65YOmumOsTFFoMuQ==
+"@pulumi/aws-native@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws-native/-/aws-native-1.5.0.tgz#ade142eebae2e2b44329b1811fbf9b24f8288a06"
+  integrity sha512-zgPrsGnYS1daHlOd3yyRhP/kmuYjRRnqjb4PIStPK3NDWXn46NA+CqV/SUHJzqQfSI8EQbkrJq95hw+WrZ/DAQ==
   dependencies:
     "@pulumi/pulumi" "^3.136.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,10 +1028,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@pulumi/aws-native@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws-native/-/aws-native-1.5.0.tgz#ade142eebae2e2b44329b1811fbf9b24f8288a06"
-  integrity sha512-zgPrsGnYS1daHlOd3yyRhP/kmuYjRRnqjb4PIStPK3NDWXn46NA+CqV/SUHJzqQfSI8EQbkrJq95hw+WrZ/DAQ==
+"@pulumi/aws-native@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws-native/-/aws-native-1.6.0.tgz#8947829fb7fdcef8ce62fe43082b668068281101"
+  integrity sha512-7b6CVr8XoprdQCWCnmPDhHe+BGHN2LSk+qpeELp8M2YjcwEu2XkFhI7bAj2UjQLcD84HwPM07baM5f2uryrZxA==
   dependencies:
     "@pulumi/pulumi" "^3.136.0"
 


### PR DESCRIPTION
Depends on https://github.com/pulumi/pulumi-aws-native/pull/1797

Because of https://github.com/pulumi/pulumi-aws-native/issues/1798 we need to add a special case for Ipv6 cidr blocks that are added to the VPC via a `VPCCidrBlock` resource.

This PR adds special handling where we track both the `Vpc` and the `VpcCidrBlock` resource and swap any references.