### PR TITLE
Fixes debug logging of CfnResource

### DIFF
--- a/src/interop.ts
+++ b/src/interop.ts
@@ -94,7 +94,9 @@ export class CfnResource extends pulumi.CustomResource {
     ) {
         const resourceName = typeToken(type);
 
-        debug(`CfnResource ${resourceName}: ${JSON.stringify(properties)}, ${JSON.stringify(attributes)}`);
+        debug(`Constructing CfnResource ${name} of type ${resourceName} with attributes=${JSON.stringify(attributes)}`);
+        const propertiesDebugString = pulumi.output(properties).apply(JSON.stringify);
+        pulumi.interpolate`CfnResource ${name} input properties: ${propertiesDebugString}`.apply(debug);
 
         // Prepare an args bag with placeholders for output attributes.
         const args: any = {};


### PR DESCRIPTION
Before this change, logging could generate "not supported" errors in the stream.

    I1104 14:23:22.081768   66128 eventsink.go:59] CfnResource aws-native:ec2:SubnetRouteTableAssociation:
    {"routeTableId":"Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a JSON value
    or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v => JSON.stringify(v))\n\nSee
    https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw in a future version of
    @pulumi/pulumi.","subnetId":"Calling [toJSON] on an [Output<T>] is not supported.\n\nTo get the value of an Output as a
    JSON value or JSON string consider either:\n    1: o.apply(v => v.toJSON())\n    2: o.apply(v =>
    JSON.stringify(v))\n\nSee https://www.pulumi.com/docs/concepts/inputs-outputs for more details.\nThis function may throw
    in a future version of @pulumi/pulumi."}, ["awsId","routeTableId","subnetId"]

After the change, debug logging should happen only after the outputs are resolved.

There is a slight downside for unknowns - debug logging will not happen when some of the properties are unknown anymore, because this will make `pulumi.output(x)` unknown and will not call `debug` in `apply`.

Note also that running programs under PULUMI_DEBUG_GRPC="$PWD/log.json" environment variable should also make it possible to observe how the underlying resources are constructed in terms of calls to the backing provider, including observing unknowns.