### PR TITLE
Handle SecretsManager dynamic references

### DIFF
--- a/integration/examples_nodejs_test.go
+++ b/integration/examples_nodejs_test.go
@@ -41,6 +41,15 @@ func TestApiGatewayDomain(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestSecretsManagerGateway(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: filepath.Join(getCwd(t), "secretsmanager"),
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	base := getBaseOptions(t)
 	baseJS := base.With(integration.ProgramTestOptions{

--- a/integration/examples_nodejs_test.go
+++ b/integration/examples_nodejs_test.go
@@ -45,7 +45,7 @@ func TestSecretsManager(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "secretsmanager"),
-      })
+		})
 
 	integration.ProgramTest(t, &test)
 }

--- a/integration/secretsmanager/Pulumi.yaml
+++ b/integration/secretsmanager/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-aws-secretsmanager
+runtime: nodejs
+description: secretsmanager integration test

--- a/integration/secretsmanager/index.ts
+++ b/integration/secretsmanager/index.ts
@@ -1,0 +1,84 @@
+import * as aws from '@pulumi/aws';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as rds from 'aws-cdk-lib/aws-rds';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as secrets from 'aws-cdk-lib/aws-secretsmanager';
+import * as pulumicdk from '@pulumi/cdk';
+import { CfnOutput, SecretValue } from 'aws-cdk-lib';
+
+class SecretsManagerStack extends pulumicdk.Stack {
+    constructor(app: pulumicdk.App, id: string, options?: pulumicdk.StackOptions) {
+        super(app, id, options);
+
+        const vpc = new ec2.Vpc(this, 'Vpc', {
+            maxAzs: 2,
+            ipAddresses: ec2.IpAddresses.cidr('10.0.0.0/16'),
+            natGateways: 0,
+            subnetConfiguration: [
+                {
+                    name: 'Isolated',
+                    subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
+                },
+            ],
+        });
+        new rds.DatabaseInstance(this, 'Instance', {
+            vpc,
+            engine: rds.DatabaseInstanceEngine.mysql({
+                version: rds.MysqlEngineVersion.VER_8_0_37,
+            }),
+            vpcSubnets: vpc.selectSubnets({ subnetType: ec2.SubnetType.PRIVATE_ISOLATED }),
+            credentials: rds.Credentials.fromGeneratedSecret('admin'),
+        });
+
+        const role = new iam.Role(this, 'Role', {
+            assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+        });
+        const secret = new secrets.Secret(this, 'Secret', {
+            description: 'A test secret',
+        });
+        secret.grantRead(role);
+
+        const rotationLambda = new lambda.Function(this, 'RotationLambda', {
+            code: lambda.Code.fromInline('exports.handler = async function(event) { return event; }'),
+            handler: 'index.handler',
+            runtime: lambda.Runtime.NODEJS_LATEST,
+        });
+        secret.addRotationSchedule('rotation', {
+            rotationLambda,
+        });
+    }
+}
+
+new pulumicdk.App(
+    'app',
+    (scope: pulumicdk.App) => {
+        new SecretsManagerStack(scope, 'teststack');
+    },
+    {
+        appOptions: {
+            remapCloudControlResource: (logicalId, typeName, props, options) => {
+                if (typeName === 'AWS::SecretsManager::RotationSchedule') {
+                    if (props.HostedRotationLambda) {
+                        throw new Error('Hosted Rotation is not supported');
+                    }
+                    return new aws.secretsmanager.SecretRotation(
+                        logicalId,
+                        {
+                            secretId: props.SecretId,
+                            rotationRules: {
+                                duration: props.RotationRules.Duration,
+                                scheduleExpression: props.RotationRules.ScheduleExpression,
+                                automaticallyAfterDays: props.RotationRules.AutomaticallyAfterDays,
+                            },
+                            rotateImmediately: props.RotateImmediatelyOnUpdate,
+                            rotationLambdaArn: props.RotationLambdaARN,
+                        },
+                        options,
+                    );
+                }
+                return undefined;
+            },
+        },
+    },
+);

--- a/integration/secretsmanager/index.ts
+++ b/integration/secretsmanager/index.ts
@@ -1,11 +1,9 @@
-import * as aws from '@pulumi/aws';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as rds from 'aws-cdk-lib/aws-rds';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as secrets from 'aws-cdk-lib/aws-secretsmanager';
 import * as pulumicdk from '@pulumi/cdk';
-import { CfnOutput, SecretValue } from 'aws-cdk-lib';
 
 class SecretsManagerStack extends pulumicdk.Stack {
     constructor(app: pulumicdk.App, id: string, options?: pulumicdk.StackOptions) {
@@ -50,35 +48,6 @@ class SecretsManagerStack extends pulumicdk.Stack {
     }
 }
 
-new pulumicdk.App(
-    'app',
-    (scope: pulumicdk.App) => {
-        new SecretsManagerStack(scope, 'teststack');
-    },
-    {
-        appOptions: {
-            remapCloudControlResource: (logicalId, typeName, props, options) => {
-                if (typeName === 'AWS::SecretsManager::RotationSchedule') {
-                    if (props.HostedRotationLambda) {
-                        throw new Error('Hosted Rotation is not supported');
-                    }
-                    return new aws.secretsmanager.SecretRotation(
-                        logicalId,
-                        {
-                            secretId: props.SecretId,
-                            rotationRules: {
-                                duration: props.RotationRules.Duration,
-                                scheduleExpression: props.RotationRules.ScheduleExpression,
-                                automaticallyAfterDays: props.RotationRules.AutomaticallyAfterDays,
-                            },
-                            rotateImmediately: props.RotateImmediatelyOnUpdate,
-                            rotationLambdaArn: props.RotationLambdaARN,
-                        },
-                        options,
-                    );
-                }
-                return undefined;
-            },
-        },
-    },
-);
+new pulumicdk.App('app', (scope: pulumicdk.App) => {
+    new SecretsManagerStack(scope, 'teststack');
+});

--- a/integration/secretsmanager/package.json
+++ b/integration/secretsmanager/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "pulumi-aws-cdk",
+    "devDependencies": {
+        "@types/node": "^10.0.0"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^6.56.0",
+        "@pulumi/aws-native": "^1.5.0",
+        "@pulumi/cdk": "^0.5.0",
+        "@pulumi/pulumi": "^3.0.0",
+        "aws-cdk-lib": "2.149.0",
+        "constructs": "10.3.0",
+        "esbuild": "^0.24.0"
+    }
+}

--- a/integration/secretsmanager/tsconfig.json
+++ b/integration/secretsmanager/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2019",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "include": [
+        "./*.ts"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -21,16 +21,16 @@
     }
   },
   "resolutions": {
-    "@pulumi/pulumi": "3.121.0", 
+    "@pulumi/pulumi": "3.136.0", 
     "wrap-ansi": "7.0.0",
     "string-width": "4.1.0"
   },
   "devDependencies": {
     "@aws-cdk/aws-apprunner-alpha": "2.20.0-alpha.0",
-    "@pulumi/aws": "^6.32.0",
-    "@pulumi/aws-native": "^1.0.0",
+    "@pulumi/aws": "^6.56.0",
+    "@pulumi/aws-native": "^1.6.0",
     "@pulumi/docker": "^4.5.0",
-    "@pulumi/pulumi": "3.121.0",
+    "@pulumi/pulumi": "3.136.0",
     "@types/archiver": "^6.0.2",
     "@types/fs-extra": "^11.0.4",
     "@types/jest": "^29.5.2",
@@ -50,10 +50,10 @@
     "typescript-eslint": "^7.16.1"
   },
   "peerDependencies": {
-    "@pulumi/aws": "^6.32.0",
-    "@pulumi/aws-native": "^1.0.0",
+    "@pulumi/aws": "^6.56.0",
+    "@pulumi/aws-native": "^1.6.0",
     "@pulumi/docker": "^4.5.0",
-    "@pulumi/pulumi": "^3.117.0",
+    "@pulumi/pulumi": "^3.136.0",
     "aws-cdk-lib": "^2.20.0",
     "constructs": "^10.0.111"
   },

--- a/src/converters/app-converter.ts
+++ b/src/converters/app-converter.ts
@@ -32,8 +32,15 @@ const SECRETS_MANAGER_DYNAMIC_REGEX =
     //                            secret-id        secret-string  json-key    version-stage version-id
     /\{\{resolve:secretsmanager:([^:]+(?::[^:]+)*?)(?::([^:]*))?(?::([^:]*))?(?::([^:]*))?(?::([^:]*))?\}\}/;
 
-const SECRETS_MANAGER_DYNAMIC_REGEX_END = /(?::([^:]*))?(?::([^:]*))?(?::([^:]*))?(?::([^:]*))?\}\}/;
-export interface SecretsManagerDynamicReferenceEnd {
+export interface SecretsManagerDynamicReference {
+    /**
+     * The name or ARN of the secret.
+     *
+     * To access a secret in your AWS account, you need only specify the secret name.
+     * To access a secret in a different AWS account, specify the complete ARN of the secret.
+     */
+    secretId: string;
+
     /**
      * Currently, the only supported value is SecretString. The default is SecretString.
      */
@@ -65,15 +72,6 @@ export interface SecretsManagerDynamicReferenceEnd {
      */
     versionId?: string;
 }
-export interface SecretsManagerDynamicReference extends SecretsManagerDynamicReferenceEnd {
-    /**
-     * The name or ARN of the secret.
-     *
-     * To access a secret in your AWS account, you need only specify the secret name.
-     * To access a secret in a different AWS account, specify the complete ARN of the secret.
-     */
-    secretId: string;
-}
 
 /**
  * Parses a secretsmanager dynamic reference into its components. This function should be used to resolve
@@ -97,41 +95,6 @@ export function parseDynamicSecretReference(secret: string): SecretsManagerDynam
         };
     }
     throw new Error(`Invalid Secrets Manager dynamic reference: value: ${secret}`);
-}
-
-/**
- * Parses a secretsmanager dynamic reference into its components. This function should be used to resolve
- * the end part of the reference string from the :secret-string onwards
- *
- * This is useful in cases where the full reference contains unresolved values, e.g.
- *
- *   "MasterUserPassword": {
- *    "Fn::Join": [
- *     "",
- *     [
- *      "{{resolve:secretsmanager:",
- *      {
- *       "Ref": "teststackInstanceSecret9DA5226D3fdaad7efa858a3daf9490cf0a702aeb"
- *      },
- *      ":SecretString:password::}}"
- *     ]
- *    ]
- *   },
- * @param referencePart - The dynamic reference end part, i.e. :secret-string:json-key:version-stage:version-id}}
- * @returns the matched secret reference
- */
-export function parseDynamicSecretReferenceInfo(referencePart: string): SecretsManagerDynamicReferenceEnd {
-    const match = referencePart.match(SECRETS_MANAGER_DYNAMIC_REGEX_END);
-    if (match) {
-        const [_, secretString, jsonKey, versionStage, versionId] = match;
-        return {
-            secretString: secretString || undefined,
-            jsonKey: jsonKey || undefined,
-            versionStage: versionStage || undefined,
-            versionId: versionId || undefined,
-        };
-    }
-    throw new Error(`Invalid Secrets Manager dynamic reference: value: ${referencePart}`);
 }
 
 /**
@@ -434,7 +397,7 @@ export class StackConverter extends ArtifactConverter {
      * @param secret - The complete secret reference string
      * @returns The secretsmanager secret value
      */
-    private resolveSecretsManagerDynamicReferenceString(secret: string): pulumi.Output<any> {
+    private resolveSecretsManagerDynamicReference(secret: string): pulumi.Output<any> {
         // This shouldn't happen because we currently only call this where we know we have a string
         // but adding this for completeness
         if (containsEventuals(secret)) {
@@ -450,34 +413,6 @@ export class StackConverter extends ArtifactConverter {
         );
     }
 
-    /**
-     * Used to resolve Secrets Manager dynamic references that contain an `Fn::Join`
-     * e.g.
-     *
-     * "Fn::Join": [
-     *   "",
-     *   [
-     *     "{{resolve:secretsmanager:",
-     *     {
-     *       "Ref": "teststackInstanceSecret9DA5226D3fdaad7efa858a3daf9490cf0a702aeb"
-     *     },
-     *     ":SecretString:password::}}"
-     *   ]
-     * ]
-     *
-     * CDK will either reference secrets using the complete string or using an array with the `Fn::Join` intrinsic
-     *
-     * @param secret - The secret reference array that is part of the `Fn::Join` intrinsic
-     * @returns The secretsmanager secret value
-     */
-    private resolveSecretsManagerDynamicReferenceArray(secret: string[]): pulumi.Output<any>[] {
-        const ref = secret[1];
-        const secretInfo = secret[2];
-        const arn = this.processIntrinsics(ref);
-        const info = parseDynamicSecretReferenceInfo(secretInfo);
-        return [getSecretVersionOutput(arn, info.versionId, info.versionStage, info.jsonKey, this.stackResource)];
-    }
-
     public processIntrinsics(obj: any): any {
         try {
             debug(`Processing intrinsics for ${JSON.stringify(obj)}`);
@@ -485,9 +420,6 @@ export class StackConverter extends ArtifactConverter {
             // just don't log
         }
         if (typeof obj === 'string') {
-            if (obj.startsWith('{{resolve:secretsmanager:')) {
-                return this.resolveSecretsManagerDynamicReferenceString(obj);
-            }
             return obj;
         }
 
@@ -496,9 +428,6 @@ export class StackConverter extends ArtifactConverter {
         }
 
         if (Array.isArray(obj)) {
-            if (obj[0] === '{{resolve:secretsmanager:' && obj.length === 3) {
-                return this.resolveSecretsManagerDynamicReferenceArray(obj);
-            }
             return obj.filter((x) => !this.isNoValue(x)).map((x) => this.processIntrinsics(x));
         }
 
@@ -512,9 +441,41 @@ export class StackConverter extends ArtifactConverter {
             return this.resolveIntrinsic(keys[0], obj[keys[0]]);
         }
 
+        // This is where we can do any final processing on the resolved value
+        // For example, if we have a value that contains intrinsics and refs, like:
+        // "Fn::Join": [
+        //    "",
+        //    [
+        //      "{{resolve:secretsmanager:",
+        //      {
+        //        "Ref": "somesecretlogicalId"
+        //      },
+        //      ":SecretString:password:AWSCURRENT}}"
+        //    ]
+        // ]
+        //
+        // Then we will recurse through that object resolving the ref and the join
+        // and eventually get to the point where we have a string that looks like:
+        // "{{resolve:secretsmanager:arn:aws:secretsmanager:us-east-2:12345678910:secret:somesecretid-abcd:SecretString:password:AWSCURRENT}}"
         return Object.entries(obj)
             .filter(([_, v]) => !this.isNoValue(v))
-            .reduce((result, [k, v]) => ({ ...result, [k]: this.processIntrinsics(v) }), {});
+            .reduce((result, [k, v]) => {
+                let value = this.processIntrinsics(v);
+                if (pulumi.Output.isInstance(value)) {
+                    value = value.apply((v) => {
+                        if (typeof v === 'string' && v.startsWith('{{resolve:secretsmanager:')) {
+                            return this.resolveSecretsManagerDynamicReference(v);
+                        }
+                        return v;
+                    });
+                } else if (typeof value === 'string' && value.startsWith('{{resolve:secretsmanager:')) {
+                    value = this.resolveSecretsManagerDynamicReference(value);
+                }
+                return {
+                    ...result,
+                    [k]: value,
+                };
+            }, {});
     }
 
     private isNoValue(obj: any): boolean {

--- a/src/converters/secrets-manager-dynamic.ts
+++ b/src/converters/secrets-manager-dynamic.ts
@@ -1,0 +1,133 @@
+import * as aws from '@pulumi/aws';
+import * as pulumi from '@pulumi/pulumi';
+import { containsEventuals } from '../types';
+
+/**
+ * The regular expression used to match a Secrets Manager dynamic reference.
+ *
+ * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references-secretsmanager.html
+ */
+const SECRETS_MANAGER_DYNAMIC_REGEX =
+    //                            secret-id        secret-string  json-key    version-stage version-id
+    /\{\{resolve:secretsmanager:([^:]+(?::[^:]+)*?)(?::([^:]*))?(?::([^:]*))?(?::([^:]*))?(?::([^:]*))?\}\}/;
+
+export interface SecretsManagerDynamicReference {
+    /**
+     * The name or ARN of the secret.
+     *
+     * To access a secret in your AWS account, you need only specify the secret name.
+     * To access a secret in a different AWS account, specify the complete ARN of the secret.
+     */
+    secretId: string;
+
+    /**
+     * Currently, the only supported value is SecretString. The default is SecretString.
+     */
+    secretString?: string;
+
+    /**
+     * The key name of the key-value pair whose value you want to retrieve.
+     * If you don't specify a json-key, CloudFormation retrieves the entire secret text.
+     *
+     * This segment may not include the colon character ( :).
+     */
+    jsonKey?: string;
+
+    /**
+     * The staging label of the version of the secret to use.
+     * If you use version-stage then don't specify version-id.
+     * If you don't specify either version-stage or version-id, then the default is the AWSCURRENT version.
+     *
+     * This segment may not include the colon character ( :).
+     */
+    versionStage?: string;
+
+    /**
+     * The unique identifier of the version of the secret to use.
+     * If you specify version-id, then don't specify version-stage.
+     * If you don't specify either version-stage or version-id, then the default is the AWSCURRENT version.
+     *
+     * This segment may not include the colon character ( :).
+     */
+    versionId?: string;
+}
+
+/**
+ * Parses a secretsmanager dynamic reference into its components. This function should be used to resolve
+ * references that are complete strings, i.e. no unresolved values
+ *
+ * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references-secretsmanager.html
+ *
+ * @param secret - The secretsmanager dynamic reference, i.e. {{resolve:secretsmanager:secret-id:secret-string:json-key:version-stage:version-id}}
+ * @returns the matched secret reference
+ */
+export function parseDynamicSecretReference(secret: string): SecretsManagerDynamicReference {
+    const match = secret.match(SECRETS_MANAGER_DYNAMIC_REGEX);
+    if (match) {
+        const [_, secretId, secretString, jsonKey, versionStage, versionId] = match;
+        return {
+            secretId,
+            secretString: secretString || undefined,
+            jsonKey: jsonKey || undefined,
+            versionStage: versionStage || undefined,
+            versionId: versionId || undefined,
+        };
+    }
+    throw new Error(`Invalid Secrets Manager dynamic reference: value: ${secret}`);
+}
+
+/**
+ * Used to resolve Secrets Manager dynamic references in the form of {{resolve:secretsmanager:secret-id:secret-string:json-key:version-stage:version-id}}
+ * This will only work for references that are complete strings, i.e. no unresolved values
+ *
+ * @param secret - The complete secret reference string
+ * @returns The secretsmanager secret value
+ */
+export function resolveSecretsManagerDynamicReference(parent: pulumi.Resource, secret: string): pulumi.Output<any> {
+    // This shouldn't happen because we currently only call this where we know we have a string
+    // but adding this for completeness
+    if (containsEventuals(secret)) {
+        throw new Error('Secrets Manager dynamic references cannot contain unresolved values');
+    }
+    const parts = parseDynamicSecretReference(secret);
+    return aws.secretsmanager
+        .getSecretVersionOutput(
+            {
+                secretId: parts.secretId,
+                versionId: parts.versionId,
+                versionStage: parts.versionStage,
+            },
+            { parent },
+        )
+        .apply((v) => {
+            if (parts.jsonKey) {
+                const json = JSON.parse(v.secretString);
+                return pulumi.secret(json[parts.jsonKey]);
+            }
+            return pulumi.secret(v.secretString);
+        });
+}
+
+/**
+ * Used to process a value that may contain a secretsmanager dynamic reference
+ *
+ * The value may be a pulumi output (typically if the value contains resource references) or a string.
+ *
+ * @param parent - The parent resource
+ * @param value - A fully resolved value that may contain a secretsmanager dynamic reference
+ * @returns A secret output if the value is a secretsmanager dynamic reference, otherwise the original value
+ */
+export function processSecretsManagerReferenceValue(parent: pulumi.Resource, value: any): any {
+    let returnValue = value;
+    if (pulumi.Output.isInstance(value)) {
+        returnValue = value.apply((v) => {
+            if (typeof v === 'string' && v.startsWith('{{resolve:secretsmanager:')) {
+                return resolveSecretsManagerDynamicReference(parent, v);
+            }
+            return v;
+        });
+    } else if (typeof value === 'string' && value.startsWith('{{resolve:secretsmanager:')) {
+        returnValue = resolveSecretsManagerDynamicReference(parent, value);
+    }
+    return returnValue;
+}

--- a/tests/converters/app-converter.test.ts
+++ b/tests/converters/app-converter.test.ts
@@ -1,32 +1,18 @@
 import { AppConverter, StackConverter } from '../../src/converters/app-converter';
-import { Stack } from 'aws-cdk-lib/core';
-import { AppComponent, AppOptions, PulumiStack } from '../../src/types';
+import * as native from '@pulumi/aws-native';
 import * as path from 'path';
 import * as mockfs from 'mock-fs';
 import * as pulumi from '@pulumi/pulumi';
 import { BucketPolicy } from '@pulumi/aws-native/s3';
 import { createStackManifest } from '../utils';
-import { promiseOf, setMocks } from '../mocks';
-import { CdkConstruct } from '../../src/interop';
+import { promiseOf, setMocks, MockAppComponent } from '../mocks';
+import { StackManifest } from '../../src/assembly';
+import { MockResourceArgs } from '@pulumi/pulumi/runtime';
 
-class MockAppComponent extends pulumi.ComponentResource implements AppComponent {
-    public readonly name = 'stack';
-    public readonly assemblyDir: string;
-    stacks: { [artifactId: string]: PulumiStack } = {};
-    dependencies: CdkConstruct[] = [];
-
-    component: pulumi.ComponentResource;
-    public stack: Stack;
-    public appOptions?: AppOptions | undefined;
-    constructor(dir: string) {
-        super('cdk:index:App', 'stack');
-        this.assemblyDir = dir;
-        this.registerOutputs();
-    }
-}
-
+let resources: MockResourceArgs[] = [];
 beforeAll(() => {
-    setMocks();
+    resources = [];
+    setMocks(resources);
 });
 
 describe('App Converter', () => {
@@ -181,7 +167,7 @@ describe('App Converter', () => {
     afterEach(() => {
         mockfs.restore();
     });
-    test('can convert', async () => {
+    test('can convert app', async () => {
         const mockStackComponent = new MockAppComponent('/tmp/foo/bar/does/not/exist');
         const converter = new AppConverter(mockStackComponent);
         converter.convert();

--- a/tests/converters/secretsmanager-converter.test.ts
+++ b/tests/converters/secretsmanager-converter.test.ts
@@ -1,0 +1,261 @@
+import {
+    StackConverter,
+    parseDynamicSecretReference,
+    parseDynamicSecretReferenceInfo,
+} from '../../src/converters/app-converter';
+import * as native from '@pulumi/aws-native';
+import { MockAppComponent, promiseOf, setMocks } from '../mocks';
+import { StackManifest } from '../../src/assembly';
+import { MockResourceArgs } from '@pulumi/pulumi/runtime';
+
+let resources: MockResourceArgs[] = [];
+beforeAll(() => {
+    resources = [];
+    setMocks(resources);
+});
+
+describe('parseDynamicSecretReferenceParts', () => {
+    test('basic', () => {
+        expect(parseDynamicSecretReferenceInfo('}}')).toEqual({
+            secretString: undefined,
+            jsonKey: undefined,
+            versionStage: undefined,
+            versionId: undefined,
+        });
+    });
+
+    test('basic with colons', () => {
+        expect(parseDynamicSecretReferenceInfo('::::}}')).toEqual({
+            secretString: undefined,
+            jsonKey: undefined,
+            versionStage: undefined,
+            versionId: undefined,
+        });
+    });
+
+    test('with secretId as arn and jsonKey', () => {
+        expect(parseDynamicSecretReferenceInfo(':SecretString:password::}}')).toEqual({
+            secretString: 'SecretString',
+            jsonKey: 'password',
+            versionStage: undefined,
+            versionId: undefined,
+        });
+    });
+
+    test('with jsonKey and versionStage', () => {
+        expect(parseDynamicSecretReferenceInfo(':SecretString:password:AWSPREVIOUS}}')).toEqual({
+            secretString: 'SecretString',
+            jsonKey: 'password',
+            versionStage: 'AWSPREVIOUS',
+            versionId: undefined,
+        });
+    });
+
+    test('with versionId', () => {
+        expect(parseDynamicSecretReferenceInfo(':SecretString:password::AWSPREVIOUS}}')).toEqual({
+            secretString: 'SecretString',
+            jsonKey: 'password',
+            versionId: 'AWSPREVIOUS',
+            versionStage: undefined,
+        });
+    });
+});
+
+describe('parseDynamicSecretReference', () => {
+    test('basic', () => {
+        expect(parseDynamicSecretReference('{{resolve:secretsmanager:MySecret}}')).toEqual({
+            secretId: 'MySecret',
+            secretString: undefined,
+            jsonKey: undefined,
+            versionStage: undefined,
+            versionId: undefined,
+        });
+    });
+
+    test('basic with colons', () => {
+        expect(parseDynamicSecretReference('{{resolve:secretsmanager:MySecret::::}}')).toEqual({
+            secretId: 'MySecret',
+            secretString: undefined,
+            jsonKey: undefined,
+            versionStage: undefined,
+            versionId: undefined,
+        });
+    });
+
+    test('with secretId as arn and jsonKey', () => {
+        expect(
+            parseDynamicSecretReference(
+                '{{resolve:secretsmanager:arn:aws:secretsmanager:us-east-2:12345678910:secret:teststackInstanceSecret9DA5226D3fdaad7efa858a3daf9490cf0a702aeb-73cc136-zXzZYo:SecretString:password::}}',
+            ),
+        ).toEqual({
+            secretId:
+                'arn:aws:secretsmanager:us-east-2:12345678910:secret:teststackInstanceSecret9DA5226D3fdaad7efa858a3daf9490cf0a702aeb-73cc136-zXzZYo',
+            secretString: 'SecretString',
+            jsonKey: 'password',
+            versionStage: undefined,
+            versionId: undefined,
+        });
+    });
+
+    test('with jsonKey and versionStage', () => {
+        expect(
+            parseDynamicSecretReference('{{resolve:secretsmanager:MySecret:SecretString:password:AWSPREVIOUS}}'),
+        ).toEqual({
+            secretId: 'MySecret',
+            secretString: 'SecretString',
+            jsonKey: 'password',
+            versionStage: 'AWSPREVIOUS',
+            versionId: undefined,
+        });
+    });
+
+    test('with versionId', () => {
+        expect(
+            parseDynamicSecretReference('{{resolve:secretsmanager:MySecret:SecretString:password::AWSPREVIOUS}}'),
+        ).toEqual({
+            secretId: 'MySecret',
+            secretString: 'SecretString',
+            jsonKey: 'password',
+            versionId: 'AWSPREVIOUS',
+            versionStage: undefined,
+        });
+    });
+});
+
+describe('SecretsManager tests', () => {
+    const stackManifest = (secret: any, json: boolean) => {
+        return new StackManifest({
+            id: 'stack',
+            templatePath: 'test/stack',
+            metadata: {
+                'stack/db': 'db',
+                'stack/secret': 'secret',
+            },
+            tree: {
+                path: 'stack',
+                id: 'stack',
+                children: {
+                    db: {
+                        id: 'db',
+                        path: 'stack/db',
+                        attributes: {
+                            'aws:cdk:cloudformation:type': 'AWS::RDS::DBInstance',
+                        },
+                    },
+                    secret: {
+                        id: 'secret',
+                        path: 'stack/secret',
+                        attributes: {
+                            'aws:cdk:cloudformation:type': 'AWS::SecretsManager::Secret',
+                        },
+                    },
+                },
+                constructInfo: {
+                    fqn: 'aws-cdk-lib.Stack',
+                    version: '2.149.0',
+                },
+            },
+            template: {
+                Resources: {
+                    db: {
+                        Type: 'AWS::RDS::DBInstance',
+                        Properties: {
+                            MasterUserSecret: secret,
+                        },
+                    },
+                    secret: {
+                        Type: 'AWS::SecretsManager::Secret',
+                        Properties: {
+                            Description: json ? 'json' : undefined,
+                        },
+                    },
+                },
+            },
+            dependencies: [],
+        });
+    };
+
+    test('stack can convert json ref secret', async () => {
+        // GIVEN
+        const manifest = stackManifest(
+            {
+                'Fn::Join': [
+                    '',
+                    [
+                        '{{resolve:secretsmanager:',
+                        {
+                            Ref: 'secret',
+                        },
+                        ':SecretString:password::}}',
+                    ],
+                ],
+            },
+            true,
+        );
+        const converter = new StackConverter(new MockAppComponent('/tmp/foo/bar/does/not/exist'), manifest);
+
+        // WHEN
+        converter.convert(new Set());
+
+        // THEN
+        const subnet = converter.resources.get('db')?.resource as native.rds.DbInstance;
+        const cidrBlock = await promiseOf(subnet.masterUserSecret);
+        expect(cidrBlock).toEqual('abcd');
+    });
+
+    test('stack can convert plain ref secret', async () => {
+        // GIVEN
+        const manifest = stackManifest(
+            {
+                'Fn::Join': [
+                    '',
+                    [
+                        '{{resolve:secretsmanager:',
+                        {
+                            Ref: 'secret',
+                        },
+                        '}}',
+                    ],
+                ],
+            },
+            false,
+        );
+        const converter = new StackConverter(new MockAppComponent('/tmp/foo/bar/does/not/exist'), manifest);
+
+        // WHEN
+        converter.convert(new Set());
+
+        // THEN
+        const subnet = converter.resources.get('db')?.resource as native.rds.DbInstance;
+        const cidrBlock = await promiseOf(subnet.masterUserSecret);
+        expect(cidrBlock).toEqual('abcd');
+    });
+
+    test('stack can convert plain secret', async () => {
+        // GIVEN
+        const manifest = stackManifest('{{resolve:secretsmanager:secret}}', false);
+        const converter = new StackConverter(new MockAppComponent('/tmp/foo/bar/does/not/exist'), manifest);
+
+        // WHEN
+        converter.convert(new Set());
+
+        // THEN
+        const subnet = converter.resources.get('db')?.resource as native.rds.DbInstance;
+        const cidrBlock = await promiseOf(subnet.masterUserSecret);
+        expect(cidrBlock).toEqual('abcd');
+    });
+
+    test('stack can convert plain secret json', async () => {
+        // GIVEN
+        const manifest = stackManifest('{{resolve:secretsmanager:json:SecretString:password::}}', true);
+        const converter = new StackConverter(new MockAppComponent('/tmp/foo/bar/does/not/exist'), manifest);
+
+        // WHEN
+        converter.convert(new Set());
+
+        // THEN
+        const subnet = converter.resources.get('db')?.resource as native.rds.DbInstance;
+        const cidrBlock = await promiseOf(subnet.masterUserSecret);
+        expect(cidrBlock).toEqual('abcd');
+    });
+});

--- a/tests/converters/secretsmanager-converter.test.ts
+++ b/tests/converters/secretsmanager-converter.test.ts
@@ -1,8 +1,4 @@
-import {
-    StackConverter,
-    parseDynamicSecretReference,
-    parseDynamicSecretReferenceInfo,
-} from '../../src/converters/app-converter';
+import { StackConverter, parseDynamicSecretReference } from '../../src/converters/app-converter';
 import * as native from '@pulumi/aws-native';
 import { MockAppComponent, promiseOf, setMocks } from '../mocks';
 import { StackManifest } from '../../src/assembly';
@@ -12,53 +8,6 @@ let resources: MockResourceArgs[] = [];
 beforeAll(() => {
     resources = [];
     setMocks(resources);
-});
-
-describe('parseDynamicSecretReferenceParts', () => {
-    test('basic', () => {
-        expect(parseDynamicSecretReferenceInfo('}}')).toEqual({
-            secretString: undefined,
-            jsonKey: undefined,
-            versionStage: undefined,
-            versionId: undefined,
-        });
-    });
-
-    test('basic with colons', () => {
-        expect(parseDynamicSecretReferenceInfo('::::}}')).toEqual({
-            secretString: undefined,
-            jsonKey: undefined,
-            versionStage: undefined,
-            versionId: undefined,
-        });
-    });
-
-    test('with secretId as arn and jsonKey', () => {
-        expect(parseDynamicSecretReferenceInfo(':SecretString:password::}}')).toEqual({
-            secretString: 'SecretString',
-            jsonKey: 'password',
-            versionStage: undefined,
-            versionId: undefined,
-        });
-    });
-
-    test('with jsonKey and versionStage', () => {
-        expect(parseDynamicSecretReferenceInfo(':SecretString:password:AWSPREVIOUS}}')).toEqual({
-            secretString: 'SecretString',
-            jsonKey: 'password',
-            versionStage: 'AWSPREVIOUS',
-            versionId: undefined,
-        });
-    });
-
-    test('with versionId', () => {
-        expect(parseDynamicSecretReferenceInfo(':SecretString:password::AWSPREVIOUS}}')).toEqual({
-            secretString: 'SecretString',
-            jsonKey: 'password',
-            versionId: 'AWSPREVIOUS',
-            versionStage: undefined,
-        });
-    });
 });
 
 describe('parseDynamicSecretReference', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -864,14 +864,14 @@
     proc-log "^4.0.0"
     which "^4.0.0"
 
-"@opentelemetry/api-metrics@0.32.0":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api-metrics/-/api-metrics-0.32.0.tgz#0f09f78491a4b301ddf54a8b8a38ffa99981f645"
-  integrity sha512-g1WLhpG8B6iuDyZJFRGsR+JKyZ94m5LEmY2f+duEJ9Xb4XRlLHrZvh6G34OH6GJ8iDHxfHb/sWjJ1ZpkI9yGMQ==
+"@opentelemetry/api-logs@0.52.1":
+  version "0.52.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.52.1.tgz#52906375da4d64c206b0c4cb8ffa209214654ecc"
+  integrity sha512-qnSqB2DQ9TPP96dl8cDubDvrUyWc0/sK81xHTK8eSUspzDM3bsewX903qclQFvVhgStjRWdC5bLb3kQqMkfV5A==
   dependencies:
     "@opentelemetry/api" "^1.0.0"
 
-"@opentelemetry/api@^1.0.0", "@opentelemetry/api@^1.2.0":
+"@opentelemetry/api@^1.0.0", "@opentelemetry/api@^1.9":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
@@ -888,7 +888,7 @@
   dependencies:
     "@opentelemetry/semantic-conventions" "1.27.0"
 
-"@opentelemetry/exporter-zipkin@^1.6.0":
+"@opentelemetry/exporter-zipkin@^1.25":
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.27.0.tgz#3ed984643797545c34ceb320276ed65d0df24e77"
   integrity sha512-eGMY3s4QprspFZojqsuQyQpWNFpo+oNVE/aosTbtvAlrJBAlvXcwwsOROOHOd8Y9lkU4i0FpQW482rcXkgwCSw==
@@ -898,23 +898,24 @@
     "@opentelemetry/sdk-trace-base" "1.27.0"
     "@opentelemetry/semantic-conventions" "1.27.0"
 
-"@opentelemetry/instrumentation-grpc@^0.32.0":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.32.0.tgz#5a9705a166f4f10106f502078f2ed4b8681b2ccf"
-  integrity sha512-Az6wdkPx/Mi26lT9LKFV6GhCA9prwQFPz5eCNSExTnSP49YhQ7XCjzPd2POPeLKt84ICitrBMdE1mj0zbPdLAQ==
+"@opentelemetry/instrumentation-grpc@^0.52":
+  version "0.52.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.52.1.tgz#906ce4756a0eb1b050cd89b6b97dc09efe3ae3e3"
+  integrity sha512-EdSDiDSAO+XRXk/ZN128qQpBo1I51+Uay/LUPcPQhSRGf7fBPIEUBeOLQiItguGsug5MGOYjql2w/1wCQF3fdQ==
   dependencies:
-    "@opentelemetry/api-metrics" "0.32.0"
-    "@opentelemetry/instrumentation" "0.32.0"
-    "@opentelemetry/semantic-conventions" "1.6.0"
+    "@opentelemetry/instrumentation" "0.52.1"
+    "@opentelemetry/semantic-conventions" "1.25.1"
 
-"@opentelemetry/instrumentation@0.32.0", "@opentelemetry/instrumentation@^0.32.0":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.32.0.tgz#27c5975a323a2ba83d9bf2ea8b11faaab37c5827"
-  integrity sha512-y6ADjHpkUz/v1nkyyYjsQa/zorhX+0qVGpFvXMcbjU4sHnBnC02c6wcc93sIgZfiQClIWo45TGku1KQxJ5UUbQ==
+"@opentelemetry/instrumentation@0.52.1", "@opentelemetry/instrumentation@^0.52":
+  version "0.52.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.52.1.tgz#2e7e46a38bd7afbf03cf688c862b0b43418b7f48"
+  integrity sha512-uXJbYU/5/MBHjMp1FqrILLRuiJCs3Ofk0MeRDk8g1S1gD47U8X3JnSwcMO1rtRo1x1a7zKaQHaoYu49p/4eSKw==
   dependencies:
-    "@opentelemetry/api-metrics" "0.32.0"
-    require-in-the-middle "^5.0.3"
-    semver "^7.3.2"
+    "@opentelemetry/api-logs" "0.52.1"
+    "@types/shimmer" "^1.0.2"
+    import-in-the-middle "^1.8.1"
+    require-in-the-middle "^7.1.1"
+    semver "^7.5.2"
     shimmer "^1.2.1"
 
 "@opentelemetry/propagator-b3@1.27.0":
@@ -931,7 +932,7 @@
   dependencies:
     "@opentelemetry/core" "1.27.0"
 
-"@opentelemetry/resources@1.27.0", "@opentelemetry/resources@^1.6.0":
+"@opentelemetry/resources@1.27.0", "@opentelemetry/resources@^1.25":
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-1.27.0.tgz#1f91c270eb95be32f3511e9e6624c1c0f993c4ac"
   integrity sha512-jOwt2VJ/lUD5BLc+PMNymDrUCpm5PKi1E9oSVYAvz01U/VdndGmrtV3DU1pG4AwlYhJRHbHfOUIlpBeXCPw6QQ==
@@ -939,7 +940,7 @@
     "@opentelemetry/core" "1.27.0"
     "@opentelemetry/semantic-conventions" "1.27.0"
 
-"@opentelemetry/sdk-trace-base@1.27.0", "@opentelemetry/sdk-trace-base@^1.6.0":
+"@opentelemetry/sdk-trace-base@1.27.0", "@opentelemetry/sdk-trace-base@^1.25":
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.27.0.tgz#2276e4cd0d701a8faba77382b2938853a0907b54"
   integrity sha512-btz6XTQzwsyJjombpeqCX6LhiMQYpzt2pIYNPnw0IPO/3AhT6yjnf8Mnv3ZC2A4eRYOjqrg+bfaXg9XHDRJDWQ==
@@ -948,7 +949,7 @@
     "@opentelemetry/resources" "1.27.0"
     "@opentelemetry/semantic-conventions" "1.27.0"
 
-"@opentelemetry/sdk-trace-node@^1.6.0":
+"@opentelemetry/sdk-trace-node@^1.25":
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.27.0.tgz#ee890a1fedba6a2a313190ada80e5077865a8684"
   integrity sha512-dWZp/dVGdUEfRBjBq2BgNuBlFqHCxyyMc8FsN0NX15X07mxSUO0SZRLyK/fdAVrde8nqFI/FEdMH4rgU9fqJfQ==
@@ -960,15 +961,15 @@
     "@opentelemetry/sdk-trace-base" "1.27.0"
     semver "^7.5.2"
 
-"@opentelemetry/semantic-conventions@1.27.0", "@opentelemetry/semantic-conventions@^1.6.0":
+"@opentelemetry/semantic-conventions@1.25.1":
+  version "1.25.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz#0deecb386197c5e9c2c28f2f89f51fb8ae9f145e"
+  integrity sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==
+
+"@opentelemetry/semantic-conventions@1.27.0", "@opentelemetry/semantic-conventions@^1.25":
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz#1a857dcc95a5ab30122e04417148211e6f945e6c"
   integrity sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==
-
-"@opentelemetry/semantic-conventions@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.6.0.tgz#ed410c9eb0070491cff9fe914246ce41f88d6f74"
-  integrity sha512-aPfcBeLErM/PPiAuAbNFLN5sNbZLc3KZlar27uohllN8Zs6jJbHyJU1y7cMA6W/zuq+thkaG8mujiS+3iD/FWQ==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -1028,17 +1029,17 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@pulumi/aws-native@^1.0.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws-native/-/aws-native-1.3.0.tgz#10f654daa1cc578ab78a25ef614f888dd23e3276"
-  integrity sha512-egocWUmAmrRk+/LWof3yWdn+qrLy9rHUmrg5XjRP1SUo7pQgqEYMKY6IlV/81NV2zcdk6t65YOmumOsTFFoMuQ==
+"@pulumi/aws-native@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws-native/-/aws-native-1.6.0.tgz#8947829fb7fdcef8ce62fe43082b668068281101"
+  integrity sha512-7b6CVr8XoprdQCWCnmPDhHe+BGHN2LSk+qpeELp8M2YjcwEu2XkFhI7bAj2UjQLcD84HwPM07baM5f2uryrZxA==
   dependencies:
     "@pulumi/pulumi" "^3.136.0"
 
-"@pulumi/aws@^6.32.0":
-  version "6.56.1"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-6.56.1.tgz#528692aff97ecc554fad68872d6a5699ff4cbec3"
-  integrity sha512-fnYs39xUPjT0cipdl28Eiw7B5ZLlHyXBd8lV7dOedKCrrfDLr/nwsh6FMPgj5nUDklR3RAzMFPUW37gMaznPoA==
+"@pulumi/aws@^6.56.0":
+  version "6.57.0"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-6.57.0.tgz#3f41e2645f3ff0d41c2952b5bef0532d7b5a7b09"
+  integrity sha512-cFwb7EbbfWntByGuyNmQAZaTXyJu1Wxcuw8aWsBS5xF/C/28iYUooRFXWT37sjYbFtYqTDYGG+LSsg+WKl1yHw==
   dependencies:
     "@pulumi/pulumi" "^3.136.0"
     builtin-modules "3.0.0"
@@ -1053,22 +1054,22 @@
     "@pulumi/pulumi" "^3.136.0"
     semver "^5.4.0"
 
-"@pulumi/pulumi@3.121.0", "@pulumi/pulumi@^3.136.0":
-  version "3.121.0"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-3.121.0.tgz#0671a73a56d4cdf6614837e4a9e2d1e531c9d44b"
-  integrity sha512-fv9sY1e7nPeGpvlHIMZcErHeZAsbdqOi0Jcb1oxi0NvTU3jy1EZa70q+JdE0dmqYlr43HaSL8SU5+G0/S08wGA==
+"@pulumi/pulumi@3.136.0", "@pulumi/pulumi@^3.136.0":
+  version "3.136.0"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-3.136.0.tgz#52bf15335abadbd9a40b07a7ad7d745b7ba89650"
+  integrity sha512-8RWX7yoxxDXZxXhJyfKrKpetSuSJzIirW16vF4naKoqF0aUDYE+6gGUrFttEfikGxaEXie4YT1UFnwuCGbXhTw==
   dependencies:
     "@grpc/grpc-js" "^1.10.1"
     "@logdna/tail-file" "^2.0.6"
     "@npmcli/arborist" "^7.3.1"
-    "@opentelemetry/api" "^1.2.0"
-    "@opentelemetry/exporter-zipkin" "^1.6.0"
-    "@opentelemetry/instrumentation" "^0.32.0"
-    "@opentelemetry/instrumentation-grpc" "^0.32.0"
-    "@opentelemetry/resources" "^1.6.0"
-    "@opentelemetry/sdk-trace-base" "^1.6.0"
-    "@opentelemetry/sdk-trace-node" "^1.6.0"
-    "@opentelemetry/semantic-conventions" "^1.6.0"
+    "@opentelemetry/api" "^1.9"
+    "@opentelemetry/exporter-zipkin" "^1.25"
+    "@opentelemetry/instrumentation" "^0.52"
+    "@opentelemetry/instrumentation-grpc" "^0.52"
+    "@opentelemetry/resources" "^1.25"
+    "@opentelemetry/sdk-trace-base" "^1.25"
+    "@opentelemetry/sdk-trace-node" "^1.25"
+    "@opentelemetry/semantic-conventions" "^1.25"
     "@pulumi/query" "^0.3.0"
     "@types/google-protobuf" "^3.15.5"
     "@types/semver" "^7.5.6"
@@ -1373,6 +1374,11 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
   integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
 
+"@types/shimmer@^1.0.2":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/shimmer/-/shimmer-1.2.0.tgz#9b706af96fa06416828842397a70dfbbf1c14ded"
+  integrity sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==
+
 "@types/stack-utils@^2.0.0":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
@@ -1493,6 +1499,11 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
+acorn-import-attributes@^1.9.5:
+  version "1.9.5"
+  resolved "https://registry.yarnpkg.com/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz#7eb1557b1ba05ef18b5ed0ec67591bfab04688ef"
+  integrity sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -1509,6 +1520,11 @@ acorn@^8.11.0, acorn@^8.4.1, acorn@^8.9.0:
   version "8.13.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.13.0.tgz#2a30d670818ad16ddd6a35d3842dacec9e5d7ca3"
   integrity sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==
+
+acorn@^8.8.2:
+  version "8.14.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
+  integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
 
 agent-base@^7.0.2, agent-base@^7.1.0, agent-base@^7.1.1:
   version "7.1.1"
@@ -2050,7 +2066,7 @@ ci-info@^3.2.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
   integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
-cjs-module-lexer@^1.0.0:
+cjs-module-lexer@^1.0.0, cjs-module-lexer@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz#707413784dbb3a72aa11c2f2b042a0bef4004170"
   integrity sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==
@@ -2223,7 +2239,7 @@ cssesc@^3.0.0:
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.7.tgz#87945b4151a011d76d95a198d7111c865c360a52"
   integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
@@ -2965,6 +2981,16 @@ import-fresh@^3.2.1:
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
+
+import-in-the-middle@^1.8.1:
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-1.11.2.tgz#dd848e72b63ca6cd7c34df8b8d97fc9baee6174f"
+  integrity sha512-gK6Rr6EykBcc6cVWRSBR5TWf8nn6hZMYSRYqCcHa0l0d1fPK7JSYo6+Mlmck76jIX9aL/IZ71c06U2VpFwl1zA==
+  dependencies:
+    acorn "^8.8.2"
+    acorn-import-attributes "^1.9.5"
+    cjs-module-lexer "^1.2.2"
+    module-details-from-path "^1.0.3"
 
 import-local@^3.0.2:
   version "3.2.0"
@@ -4534,14 +4560,14 @@ require-from-string@^2.0.1, require-from-string@^2.0.2:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
-require-in-the-middle@^5.0.3:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/require-in-the-middle/-/require-in-the-middle-5.2.0.tgz#4b71e3cc7f59977100af9beb76bf2d056a5a6de2"
-  integrity sha512-efCx3b+0Z69/LGJmm9Yvi4cqEdxnoGnxYxGxBghkkTTFeXRtTCmmhO0AnAfHz59k957uTSuy8WaHqOs8wbYUWg==
+require-in-the-middle@^7.1.1:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/require-in-the-middle/-/require-in-the-middle-7.4.0.tgz#606977820d4b5f9be75e5a108ce34cfed25b3bb4"
+  integrity sha512-X34iHADNbNDfr6OTStIAHWSAvvKQRYgLO6duASaVf7J2VA3lvmNYboAHOuLC2huav1IwgZJtyEcJCKVzFxOSMQ==
   dependencies:
-    debug "^4.1.1"
+    debug "^4.3.5"
     module-details-from-path "^1.0.3"
-    resolve "^1.22.1"
+    resolve "^1.22.8"
 
 resolve-alpn@^1.0.0:
   version "1.2.1"
@@ -4570,7 +4596,7 @@ resolve.exports@^2.0.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.2.tgz#f8c934b8e6a13f539e38b7098e2e36134f01e800"
   integrity sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==
 
-resolve@^1.20.0, resolve@^1.22.1, resolve@^1.7.1:
+resolve@^1.20.0, resolve@^1.22.8, resolve@^1.7.1:
   version "1.22.8"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
   integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
@@ -4645,7 +4671,7 @@ semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.1.1, semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.2, semver@^7.6.3:
+semver@^7.1.1, semver@^7.3.5, semver@^7.3.7, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.2, semver@^7.6.3:
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==


### PR DESCRIPTION
CloudFormation has a capability that allows you to dynamically resolve secretsmanager values at deploy time.

This PR adds special handling for these values by mapping them to the `getSecretVersion` function. I can think of two ways that these values would end up being referenced in a CDK application

1. The user provides a string value for the secretId and the reference is a complete string.
2. The user provides a reference value for the secretId and the reference is a Fn::Join intrinsic

There may be other cases, but if there are I think they are not very common and we can handle them if users create issues.

re #183, fixes #199