### PR TITLE
Add support for Route53 records

### DIFF
--- a/integration/examples_nodejs_test.go
+++ b/integration/examples_nodejs_test.go
@@ -50,6 +50,20 @@ func TestEc2(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestRoute53(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: filepath.Join(getCwd(t), "route53"),
+			Config: map[string]string{
+				// This test has to be run in us-east-1 for DNSSEC
+				"aws:region":        "us-east-1",
+				"aws-native:region": "us-east-1",
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	base := getBaseOptions(t)
 	baseJS := base.With(integration.ProgramTestOptions{

--- a/integration/route53/Pulumi.yaml
+++ b/integration/route53/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-aws-route53
+runtime: nodejs
+description: route53 integration test

--- a/integration/route53/index.ts
+++ b/integration/route53/index.ts
@@ -1,0 +1,84 @@
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as route53 from 'aws-cdk-lib/aws-route53';
+import * as pulumicdk from '@pulumi/cdk';
+import { Duration } from 'aws-cdk-lib/core';
+import { aws_elasticloadbalancingv2, aws_kms, aws_route53_targets } from 'aws-cdk-lib';
+
+class Route53Stack extends pulumicdk.Stack {
+    constructor(app: pulumicdk.App, id: string, options?: pulumicdk.StackOptions) {
+        super(app, id, options);
+        const kmsKey = new aws_kms.Key(this, 'Key', {
+            keySpec: aws_kms.KeySpec.ECC_NIST_P256,
+            keyUsage: aws_kms.KeyUsage.SIGN_VERIFY,
+            pendingWindow: Duration.days(7),
+        });
+        const zone = new route53.HostedZone(this, 'HostedZone', {
+            zoneName: 'pulumi-cdk.com',
+        });
+        zone.enableDnssec({
+            kmsKey,
+        });
+
+        new route53.TxtRecord(this, 'TxtRecord', {
+            zone,
+            values: ['somevalue'],
+            recordName: 'cdk-txt',
+        });
+
+        new route53.TxtRecord(this, 'TxtRecord2', {
+            zone,
+            values: ['hello'.repeat(52)],
+            recordName: 'cdk-txt-2',
+        });
+
+        new route53.CnameRecord(this, 'Cname', {
+            zone,
+            recordName: 'cdk-cname',
+            domainName: 'pulumi.com',
+            ttl: Duration.minutes(1),
+        });
+
+        new route53.ARecord(this, 'ARecord', {
+            zone,
+            recordName: 'cdk-a',
+            target: route53.RecordTarget.fromIpAddresses('1.2.3.4'),
+            geoLocation: route53.GeoLocation.continent(route53.Continent.NORTH_AMERICA),
+        });
+
+        const vpc = new ec2.Vpc(this, 'Vpc', {
+            maxAzs: 2,
+            ipAddresses: ec2.IpAddresses.cidr('10.0.0.0/16'),
+            natGateways: 0,
+            subnetConfiguration: [
+                {
+                    name: 'Isolated',
+                    subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
+                },
+            ],
+        });
+        const privateZone = new route53.PrivateHostedZone(this, 'PrivateHostedZone', {
+            zoneName: 'pulumi-cdk-private.com',
+            vpc,
+        });
+        const nlb = new aws_elasticloadbalancingv2.NetworkLoadBalancer(this, 'NLB', {
+            vpc,
+            vpcSubnets: vpc.selectSubnets({ subnetType: ec2.SubnetType.PRIVATE_ISOLATED }),
+        });
+        new route53.AaaaRecord(this, 'AaaaRecord1', {
+            recordName: 'nlb',
+            zone: privateZone,
+            target: route53.RecordTarget.fromAlias(new aws_route53_targets.LoadBalancerTarget(nlb)),
+            weight: 1,
+        });
+        new route53.AaaaRecord(this, 'AaaaRecord2', {
+            recordName: 'nlb',
+            zone: privateZone,
+            target: route53.RecordTarget.fromAlias(new aws_route53_targets.LoadBalancerTarget(nlb)),
+            weight: 2,
+        });
+    }
+}
+
+new pulumicdk.App('app', (scope: pulumicdk.App) => {
+    new Route53Stack(scope, 'teststack');
+});

--- a/integration/route53/package.json
+++ b/integration/route53/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "pulumi-aws-cdk",
+    "devDependencies": {
+        "@types/node": "^10.0.0"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/aws-native": "^1.5.0",
+        "@pulumi/cdk": "^0.5.0",
+        "@pulumi/pulumi": "^3.0.0",
+        "aws-cdk-lib": "2.149.0",
+        "constructs": "10.3.0",
+        "esbuild": "^0.24.0"
+    }
+}

--- a/integration/route53/tsconfig.json
+++ b/integration/route53/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2019",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "include": [
+        "./*.ts"
+    ]
+}


### PR DESCRIPTION
This PR adds support for Route53 records (`AWS::Route53::RecordSet`) which is not currently supported by CCAPI.

I've also added integration tests for the Route53 constructs.

re #183, closes #177