### PR TITLE
Add docker image support

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -16,12 +16,15 @@ package examples
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -70,6 +73,19 @@ func TestFargate(t *testing.T) {
 			Dir:              filepath.Join(getCwd(t), "fargate"),
 			NoParallel:       true,
 			RetryFailedSteps: true, // Workaround for https://github.com/pulumi/pulumi-aws-native/issues/1186
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				url := stack.Outputs["loadBalancerURL"].(string)
+
+				resp, err := http.Get(url)
+				assert.NoError(t, err)
+				defer resp.Body.Close()
+
+				body, err := io.ReadAll(resp.Body)
+				assert.NoError(t, err)
+
+				assert.Equal(t, 200, resp.StatusCode)
+				assert.Equal(t, "Hello, world!", string(body))
+			},
 		})
 
 	integration.ProgramTest(t, &test)

--- a/examples/fargate/app/Dockerfile
+++ b/examples/fargate/app/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:lts AS builder
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+COPY app ./
+
+RUN yarn install --frozen-lockfile
+RUN npx esbuild --bundle index.ts --target="node18" --platform="node" --outfile="index.js"
+
+FROM node:18-alpine
+COPY --from=builder /app/index.js /app/index.js
+EXPOSE 80
+CMD ["node", "/app/index.js"]

--- a/examples/fargate/app/index.ts
+++ b/examples/fargate/app/index.ts
@@ -1,0 +1,14 @@
+import express, { Request, Response } from 'express';
+const app = express();
+
+app.get('/', async (_req: Request, res: Response) => {
+    res.status(200).send('Hello, world!');
+});
+
+app.get('/health', (_req: Request, res: Response) => {
+    res.status(200).send(JSON.stringify({ message: 'OK' }));
+});
+
+app.listen(80, () => {
+    console.log('Listening on port 8080');
+});

--- a/examples/fargate/index.ts
+++ b/examples/fargate/index.ts
@@ -1,11 +1,13 @@
+import * as path from 'path';
 import * as pulumi from '@pulumi/pulumi';
 import * as pulumicdk from '@pulumi/cdk';
 
-import { Duration } from 'aws-cdk-lib';
+import { AssetStaging, Duration } from 'aws-cdk-lib';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as ecs_patterns from 'aws-cdk-lib/aws-ecs-patterns';
 import { CfnTargetGroup } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 
 class FargateStack extends pulumicdk.Stack {
     loadBalancerDNS: pulumi.Output<string>;
@@ -22,7 +24,13 @@ class FargateStack extends pulumicdk.Stack {
         const fargateService = new ecs_patterns.NetworkLoadBalancedFargateService(this, 'sample-app', {
             cluster,
             taskImageOptions: {
-                image: ecs.ContainerImage.fromRegistry('amazon/amazon-ecs-sample'),
+                // image: ecs.ContainerImage.fromRegistry('amazon/amazon-ecs-sample'),
+                image: ecs.ContainerImage.fromAsset(path.join(__dirname, './'), {
+                    file: 'app/Dockerfile',
+                    exclude: ['cdk.out', 'node_modules'],
+                    assetName: 'cdk-fargate-example',
+                    platform: Platform.LINUX_AMD64,
+                }),
             },
         });
 
@@ -51,10 +59,29 @@ class FargateStack extends pulumicdk.Stack {
 
 class MyApp extends pulumicdk.App {
     constructor() {
-        super('app', (scope: pulumicdk.App): pulumicdk.AppOutputs => {
-            const stack = new FargateStack(scope, 'fargatestack');
-            return { loadBalancerURL: stack.loadBalancerDNS };
-        });
+        super(
+            'app',
+            (scope: pulumicdk.App): pulumicdk.AppOutputs => {
+                const stack = new FargateStack(scope, 'fargatestack');
+                return { loadBalancerURL: stack.loadBalancerDNS };
+            },
+            {
+                // TODO[pulumi/aws-native#1318]
+                transforms: [
+                    (args: pulumi.ResourceTransformArgs): pulumi.ResourceTransformResult => {
+                        if (args.type === 'aws-native:ecs:TaskDefinition') {
+                            args.opts.replaceOnChanges = ['containerDefinitions'];
+                        }
+                        return {
+                            opts: {
+                                ...args.opts,
+                            },
+                            props: args.props,
+                        };
+                    },
+                ],
+            },
+        );
     }
 }
 

--- a/examples/fargate/package.json
+++ b/examples/fargate/package.json
@@ -6,9 +6,13 @@
     "dependencies": {
         "@pulumi/aws": "^6.0.0",
         "@pulumi/aws-native": "^1.0.0",
+        "@pulumi/cdk": "^0.5.0",
+        "@pulumi/docker-build": "^0.0.7",
         "@pulumi/pulumi": "^3.0.0",
         "aws-cdk-lib": "2.156.0",
+        "@types/express": "^5.0.0",
         "constructs": "10.3.0",
-        "@pulumi/cdk": "^0.5.0"
+        "esbuild": "^0.24.0",
+        "express": "^4.21.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     }
   },
   "resolutions": {
-    "@pulumi/pulumi": "3.136.0", 
+    "@pulumi/pulumi": "3.136.0",
     "wrap-ansi": "7.0.0",
     "string-width": "4.1.0"
   },
@@ -30,6 +30,7 @@
     "@pulumi/aws": "^6.56.0",
     "@pulumi/aws-native": "^1.6.0",
     "@pulumi/docker": "^4.5.0",
+    "@pulumi/docker-build": "^0.0.7",
     "@pulumi/pulumi": "3.136.0",
     "@types/archiver": "^6.0.2",
     "@types/fs-extra": "^11.0.4",

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -101,6 +101,11 @@ export function setMocks(resources?: MockResourceArgs[]) {
                                   })
                                 : 'abcd',
                     };
+                case 'aws:ecr/getCredentials:getCredentials':
+                    return {
+                        authorizationToken: btoa('user:password'),
+                        proxyEndpoint: 'https://12345678910.dkr.ecr.us-east-1.amazonaws.com',
+                    };
                 default:
                     return {};
             }
@@ -117,6 +122,26 @@ export function setMocks(resources?: MockResourceArgs[]) {
                     return { id: '', state: {} };
                 case 'cdk:index:Component':
                     return { id: '', state: {} };
+                case 'docker-build:index:Image':
+                    resources?.push(args);
+                    return {
+                        id: args.inputs.name + '_id',
+                        state: {
+                            ...args.inputs,
+                            id: args.inputs.name + '_id',
+                            ref: args.inputs.tags[0] + '@sha256:abcdefghijk1023',
+                        },
+                    };
+                case 'aws:ecr/repository:Repository':
+                    resources?.push(args);
+                    return {
+                        id: args.inputs.name + '_id',
+                        state: {
+                            ...args.inputs,
+                            arn: args.name + '_arn',
+                            repositoryUrl: '12345678910.dkr.ecr.us-east-1.amazonaws.com/' + args.inputs.name,
+                        },
+                    };
                 default:
                     resources?.push(args);
                     return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,6 +1054,13 @@
     mime "^2.0.0"
     resolve "^1.7.1"
 
+"@pulumi/docker-build@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@pulumi/docker-build/-/docker-build-0.0.7.tgz#c56582dbc2d6f6a07ceebb9201a7904cd2278e6e"
+  integrity sha512-yiPvQefRS3Z+5NtG5VK2pYTds0pCQh21INpoWY8gKFrqs166ZFVrPrMXelmsjABnmkG5ZNlkHanU7HqAExn55Q==
+  dependencies:
+    "@pulumi/pulumi" "^3.136.0"
+
 "@pulumi/docker@^4.5.0":
   version "4.5.7"
   resolved "https://registry.yarnpkg.com/@pulumi/docker/-/docker-4.5.7.tgz#56ec0782a1a52b5a1dc16230dcd7e07c0b94be01"


### PR DESCRIPTION
This adds support for docker image assets by using the [pulumi/docker-build](https://github.com/pulumi/pulumi-docker-build) provider.

fixes #125