### PR TITLE
Remove CDK generated hash suffix on resource names

### DIFF
--- a/integration/examples_nodejs_test.go
+++ b/integration/examples_nodejs_test.go
@@ -103,7 +103,7 @@ func TestMisc(t *testing.T) {
 			Dir: filepath.Join(getCwd(t), "misc-services"),
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				repoName := stack.Outputs["repoName"].(string)
-				assert.Containsf(t, repoName, "testrepob5dda46f", "Expected repoName to contain 'testrepob5dda46f'; got %s", repoName)
+				assert.Containsf(t, repoName, "testrepo", "Expected repoName to contain 'testrepo'; got %s", repoName)
 			},
 		})
 
@@ -116,7 +116,7 @@ func TestCloudFront(t *testing.T) {
 			Dir: filepath.Join(getCwd(t), "cloudfront"),
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				bucketName := stack.Outputs["bucketName"].(string)
-				assert.Containsf(t, bucketName, "bucket83908e77", "Bucket name should contain 'bucket'")
+				assert.Containsf(t, bucketName, "bucket", "Bucket name should contain 'bucket'")
 			},
 		})
 

--- a/integration/replace-on-changes/index.ts
+++ b/integration/replace-on-changes/index.ts
@@ -9,7 +9,7 @@ class ReplaceOnChangesStack extends pulumicdk.Stack {
             default: true,
         }).id;
         const azs = aws.getAvailabilityZonesOutput({}).names;
-        new ec2.SecurityGroup(this, 'sg', {
+        new ec2.SecurityGroup(this, 'security-group', {
             description: 'Some Description',
             vpc: ec2.Vpc.fromVpcAttributes(this, 'vpc', {
                 vpcId: pulumicdk.asString(vpc),

--- a/integration/replace-on-changes/step2/index.ts
+++ b/integration/replace-on-changes/step2/index.ts
@@ -9,7 +9,7 @@ class ReplaceOnChangesStack extends pulumicdk.Stack {
             default: true,
         }).id;
         const azs = aws.getAvailabilityZonesOutput({}).names;
-        new ec2.SecurityGroup(this, 'sg', {
+        new ec2.SecurityGroup(this, 'security-group', {
             // description is a createOnlyProperty which means this would fail
             // if `replaceOnChanges` was not working
             description: 'Some New Description',

--- a/src/cdk-logical-id.ts
+++ b/src/cdk-logical-id.ts
@@ -1,0 +1,88 @@
+// Copyright 2018-2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// NOTE:
+// Most of this code was copied from https://github.com/aws/aws-cdk/blob/ccab485b87a7090ddf0773508d7b8ee84ff654b0/packages/aws-cdk-lib/core/lib/private/uniqueid.ts
+// with the modification of removing logic related to adding the path hash to the logicalId
+import * as cdk from 'aws-cdk-lib/core';
+/**
+ * Resources with this ID are hidden from humans
+ *
+ * They do not appear in the human-readable part of the logical ID
+ */
+const HIDDEN_FROM_HUMAN_ID = 'Resource';
+
+/**
+ * Resources with this ID are complete hidden from the logical ID calculation.
+ */
+const HIDDEN_ID = 'Default';
+const MAX_HUMAN_LEN = 240; // this is the value in CDK and seems like a good default to keep
+
+/**
+ * Calculates a unique ID for a set of textual components.
+ *
+ * This is forked from the internal cdk implementation with the removal of the hash suffix.
+ * We remove the hash from the CDK logical ID calculation because Pulumi already handles
+ * adding a unique random suffix and we do not want to end up with a double hash.
+ * @see https://github.com/aws/aws-cdk/blob/ccab485b87a7090ddf0773508d7b8ee84ff654b0/packages/aws-cdk-lib/core/lib/private/uniqueid.ts?plain=1#L32
+ *
+ * @param components The path components
+ * @returns a unique alpha-numeric identifier with a maximum length of 255
+ */
+export function makeUniqueId(components: string[]) {
+    components = components.filter((x) => x !== HIDDEN_ID);
+
+    if (components.length === 0) {
+        throw new Error('Unable to calculate a unique id for an empty set of components');
+    }
+
+    // Lazy require in order to break a module dependency cycle
+    const unresolvedTokens = components.filter((c) => cdk.Token.isUnresolved(c));
+    if (unresolvedTokens.length > 0) {
+        throw new Error(`ID components may not include unresolved tokens: ${unresolvedTokens.join(',')}`);
+    }
+
+    const human = removeDupes(components)
+        .filter((x) => x !== HIDDEN_FROM_HUMAN_ID)
+        .map(removeNonAlphanumeric)
+        .join('')
+        .slice(0, MAX_HUMAN_LEN);
+
+    return human;
+}
+
+/**
+ * Remove duplicate "terms" from the path list
+ *
+ * If the previous path component name ends with this component name, skip the
+ * current component.
+ */
+function removeDupes(path: string[]): string[] {
+    const ret = new Array<string>();
+
+    for (const component of path) {
+        if (ret.length === 0 || !ret[ret.length - 1].endsWith(component)) {
+            ret.push(component);
+        }
+    }
+
+    return ret;
+}
+
+/**
+ * Removes all non-alphanumeric characters in a string.
+ */
+function removeNonAlphanumeric(s: string) {
+    return s.replace(/[^A-Za-z0-9]/g, '');
+}

--- a/src/cdk-logical-id.ts
+++ b/src/cdk-logical-id.ts
@@ -47,7 +47,6 @@ export function makeUniqueId(components: string[]) {
         throw new Error('Unable to calculate a unique id for an empty set of components');
     }
 
-    // Lazy require in order to break a module dependency cycle
     const unresolvedTokens = components.filter((c) => cdk.Token.isUnresolved(c));
     if (unresolvedTokens.length > 0) {
         throw new Error(`ID components may not include unresolved tokens: ${unresolvedTokens.join(',')}`);

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -18,6 +18,7 @@ import { AppConverter, StackConverter } from './converters/app-converter';
 import { PulumiSynthesizer, PulumiSynthesizerBase } from './synthesizer';
 import { AwsCdkCli, ICloudAssemblyDirectoryProducer } from '@aws-cdk/cli-lib-alpha';
 import { CdkConstruct } from './interop';
+import { makeUniqueId } from './cdk-logical-id';
 
 export type AppOutputs = { [outputId: string]: pulumi.Output<any> };
 
@@ -324,75 +325,4 @@ function generateAppId(): string {
         .toLowerCase()
         .replace(/[^a-z0-9-.]/g, '-')
         .slice(-17);
-}
-
-/**
- * Resources with this ID are hidden from humans
- *
- * They do not appear in the human-readable part of the logical ID
- */
-const HIDDEN_FROM_HUMAN_ID = 'Resource';
-
-/**
- * Resources with this ID are complete hidden from the logical ID calculation.
- */
-const HIDDEN_ID = 'Default';
-const MAX_HUMAN_LEN = 240; // this is the value in CDK and seems like a good default to keep
-
-/**
- * Calculates a unique ID for a set of textual components.
- *
- * This is forked from the internal cdk implementation with the removal of the hash suffix.
- * We remove the hash from the CDK logical ID calculation because Pulumi already handles
- * adding a unique random suffix and we do not want to end up with a double hash.
- * @see https://github.com/aws/aws-cdk/blob/ccab485b87a7090ddf0773508d7b8ee84ff654b0/packages/aws-cdk-lib/core/lib/private/uniqueid.ts?plain=1#L32
- *
- * @param components The path components
- * @returns a unique alpha-numeric identifier with a maximum length of 255
- */
-function makeUniqueId(components: string[]) {
-    components = components.filter((x) => x !== HIDDEN_ID);
-
-    if (components.length === 0) {
-        throw new Error('Unable to calculate a unique id for an empty set of components');
-    }
-
-    // Lazy require in order to break a module dependency cycle
-    const unresolvedTokens = components.filter((c) => cdk.Token.isUnresolved(c));
-    if (unresolvedTokens.length > 0) {
-        throw new Error(`ID components may not include unresolved tokens: ${unresolvedTokens.join(',')}`);
-    }
-
-    const human = removeDupes(components)
-        .filter((x) => x !== HIDDEN_FROM_HUMAN_ID)
-        .map(removeNonAlphanumeric)
-        .join('')
-        .slice(0, MAX_HUMAN_LEN);
-
-    return human;
-}
-
-/**
- * Remove duplicate "terms" from the path list
- *
- * If the previous path component name ends with this component name, skip the
- * current component.
- */
-function removeDupes(path: string[]): string[] {
-    const ret = new Array<string>();
-
-    for (const component of path) {
-        if (ret.length === 0 || !ret[ret.length - 1].endsWith(component)) {
-            ret.push(component);
-        }
-    }
-
-    return ret;
-}
-
-/**
- * Removes all non-alphanumeric characters in a string.
- */
-function removeNonAlphanumeric(s: string) {
-    return s.replace(/[^A-Za-z0-9]/g, '');
 }


### PR DESCRIPTION
CDK automatically adds a hash suffix to the resource logicalId (which we
then use as the Pulumi Resource name). When pulumi autonaming takes
place we then append an additional random suffix so we end up with names
like `testapimyapiCloudWatchRoleA84BAE8E-120b18f`. Apart from this
looking bad it also takes up 16 characters for each name and increases
the likelihood of running into naming limits.

This PR overrides the `allocateLogicalId` method on the `cdk.Stack`.
Most of the code is simply forked from the CDK implementation with the
removal of the piece that generates the hash.

You can view the CDK version here
https://github.com/aws/aws-cdk/blob/ccab485b87a7090ddf0773508d7b8ee84ff654b0/packages/aws-cdk-lib/core/lib/stack.ts?plain=1#L1357

closes #185