### PR TITLE
Support Condition Functions

### DIFF
--- a/integration/examples_nodejs_test.go
+++ b/integration/examples_nodejs_test.go
@@ -264,3 +264,16 @@ func bucketExists(ctx context.Context, client *s3.Client, bucketName string) (bo
 	}
 	return true, nil
 }
+
+func TestKinesis(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: filepath.Join(getCwd(t), "kinesis"),
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				kinesisStreamName := stack.Outputs["kinesisStreamName"].(string)
+				assert.Containsf(t, kinesisStreamName, "mystream", "Kinesis stream name should contain 'mystream'")
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}

--- a/integration/kinesis/Pulumi.yaml
+++ b/integration/kinesis/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-kinesis
+runtime: nodejs
+description: kinesis integration test

--- a/integration/kinesis/index.ts
+++ b/integration/kinesis/index.ts
@@ -1,21 +1,27 @@
-import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as pulumi from '@pulumi/pulumi';
 import * as kinesis from 'aws-cdk-lib/aws-kinesis';
 import * as pulumicdk from '@pulumi/cdk';
 import { Duration } from 'aws-cdk-lib/core';
-import { aws_elasticloadbalancingv2, aws_kms, aws_route53_targets } from 'aws-cdk-lib';
 
 class KinesisStack extends pulumicdk.Stack {
+    kinesisStreamName: pulumi.Output<string>;
+
     constructor(app: pulumicdk.App, id: string, options?: pulumicdk.StackOptions) {
         super(app, id, options);
 
-        new kinesis.Stream(this, "MyFirstStream", {
-            streamName: "my-awesome-stream",
+        const kStream = new kinesis.Stream(this, 'MyFirstStream', {
+            streamName: 'my-stream',
             shardCount: 3,
             retentionPeriod: Duration.hours(24),
         })
+
+        this.kinesisStreamName = this.asOutput(kStream.streamName);
     }
 }
 
 new pulumicdk.App('app', (scope: pulumicdk.App) => {
-    new KinesisStack(scope, 'teststack');
+    const stack = new KinesisStack(scope, 'teststack');
+    return {
+        kinesisStreamName: stack.kinesisStreamName,
+    };
 });

--- a/integration/kinesis/index.ts
+++ b/integration/kinesis/index.ts
@@ -1,0 +1,21 @@
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as kinesis from 'aws-cdk-lib/aws-kinesis';
+import * as pulumicdk from '@pulumi/cdk';
+import { Duration } from 'aws-cdk-lib/core';
+import { aws_elasticloadbalancingv2, aws_kms, aws_route53_targets } from 'aws-cdk-lib';
+
+class KinesisStack extends pulumicdk.Stack {
+    constructor(app: pulumicdk.App, id: string, options?: pulumicdk.StackOptions) {
+        super(app, id, options);
+
+        new kinesis.Stream(this, "MyFirstStream", {
+            streamName: "my-awesome-stream",
+            shardCount: 3,
+            retentionPeriod: Duration.hours(24),
+        })
+    }
+}
+
+new pulumicdk.App('app', (scope: pulumicdk.App) => {
+    new KinesisStack(scope, 'teststack');
+});

--- a/integration/kinesis/index.ts
+++ b/integration/kinesis/index.ts
@@ -9,8 +9,7 @@ class KinesisStack extends pulumicdk.Stack {
     constructor(app: pulumicdk.App, id: string, options?: pulumicdk.StackOptions) {
         super(app, id, options);
 
-        const kStream = new kinesis.Stream(this, 'MyFirstStream', {
-            streamName: 'my-stream',
+        const kStream = new kinesis.Stream(this, 'my-stream', {
             shardCount: 3,
             retentionPeriod: Duration.hours(24),
         })
@@ -19,9 +18,11 @@ class KinesisStack extends pulumicdk.Stack {
     }
 }
 
-new pulumicdk.App('app', (scope: pulumicdk.App) => {
+const app = new pulumicdk.App('app', (scope: pulumicdk.App) => {
     const stack = new KinesisStack(scope, 'teststack');
     return {
         kinesisStreamName: stack.kinesisStreamName,
     };
 });
+
+export const kinesisStreamName = app.outputs['kinesisStreamName'];

--- a/integration/kinesis/package.json
+++ b/integration/kinesis/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "pulumi-kinesis",
+    "devDependencies": {
+        "@types/node": "^10.0.0"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/aws-native": "^1.8.0",
+        "@pulumi/cdk": "^0.5.0",
+        "@pulumi/pulumi": "^3.0.0",
+        "aws-cdk-lib": "2.156.0",
+        "constructs": "10.3.0",
+        "esbuild": "^0.24.0"
+    }
+}

--- a/integration/kinesis/tsconfig.json
+++ b/integration/kinesis/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2019",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "include": [
+        "./*.ts"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "@types/glob": "^8.1.0",
     "archiver": "^7.0.1",
     "cdk-assets": "^2.154.8",
-    "fs-extra": "^11.2.0"
+    "fs-extra": "^11.2.0",
+    "fast-deep-equal": "^3.1.3"
   },
   "scripts": {
     "set-version": "sed -i.bak -e \"s/\\${VERSION}/$(pulumictl get version --language javascript)/g\" package.json && rm package.json.bak",

--- a/src/assembly/stack.ts
+++ b/src/assembly/stack.ts
@@ -1,6 +1,12 @@
 import * as path from 'path';
 import { DestinationIdentifier, FileManifestEntry } from 'cdk-assets';
-import { CloudFormationMapping, CloudFormationParameter, CloudFormationResource, CloudFormationTemplate } from '../cfn';
+import {
+    CloudFormationMapping,
+    CloudFormationParameter,
+    CloudFormationResource,
+    CloudFormationTemplate,
+    CloudFormationCondition,
+} from '../cfn';
 import { ConstructTree, StackMetadata } from './types';
 import { FileAssetPackaging, FileDestination } from 'aws-cdk-lib/cloud-assembly-schema';
 
@@ -116,10 +122,15 @@ export class StackManifest {
     public readonly mappings?: CloudFormationMapping;
 
     /**
+     * CloudFormation conditions from the template.
      *
+     * @internal
      */
+    public readonly conditions?: { [id: string]: CloudFormationCondition };
+
     private readonly metadata: StackMetadata;
     public readonly dependencies: string[];
+
     constructor(props: StackManifestProps) {
         this.dependencies = props.dependencies;
         this.outputs = props.template.Outputs;
@@ -133,6 +144,7 @@ export class StackManifest {
             throw new Error('CloudFormation template has no resources!');
         }
         this.resources = props.template.Resources;
+        this.conditions = props.template.Conditions;
     }
 
     /**

--- a/src/cfn.ts
+++ b/src/cfn.ts
@@ -32,10 +32,21 @@ export type CloudFormationMappingValue = string | string[];
 export type TopLevelMapping = { [key: string]: SecondLevelMapping };
 export type SecondLevelMapping = { [key: string]: CloudFormationMappingValue };
 
+/**
+ * Models CF conditions. These are possibly nested expressions evaluating to a boolean.
+ *
+ * Example value:
+ *
+ *     {"Fn::Equals": [{"Ref": "EnvType"}, "prod"]}
+ *
+ * See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/conditions-section-structure.html
+ */
+export interface CloudFormationCondition {}
+
 export interface CloudFormationTemplate {
     Parameters?: { [id: string]: CloudFormationParameter };
     Resources?: { [id: string]: CloudFormationResource };
-    Conditions?: { [id: string]: any };
+    Conditions?: { [id: string]: CloudFormationCondition };
     Mappings?: CloudFormationMapping;
     Outputs?: { [id: string]: any };
 }

--- a/src/converters/app-converter.ts
+++ b/src/converters/app-converter.ts
@@ -543,6 +543,10 @@ export class StackConverter extends ArtifactConverter implements intrinsics.Intr
                     return value;
                 }, this.processIntrinsics(params));
 
+            case 'Fn::Equals': {
+                return intrinsics.fnEquals.evaluate(this, params);
+            }
+
             case 'Fn::If': {
                 return intrinsics.fnIf.evaluate(this, params);
             }

--- a/src/converters/app-converter.ts
+++ b/src/converters/app-converter.ts
@@ -648,7 +648,7 @@ export class StackConverter extends ArtifactConverter implements intrinsics.Intr
     }
 
     findCondition(conditionName: string): intrinsics.Expression|undefined {
-        if ((this.stack.conditions||{}).hasOwnProperty(conditionName)) {
+        if (conditionName in (this.stack.conditions||{})) {
             return this.stack.conditions![conditionName];
         } else {
             return undefined;

--- a/src/converters/app-converter.ts
+++ b/src/converters/app-converter.ts
@@ -542,6 +542,7 @@ export class StackConverter extends ArtifactConverter implements intrinsics.Intr
                     const value = secondLevelMapping[secondLevelKey];
                     return value;
                 }, this.processIntrinsics(params));
+            }
 
             case 'Fn::Equals': {
                 return intrinsics.fnEquals.evaluate(this, params);

--- a/src/converters/app-converter.ts
+++ b/src/converters/app-converter.ts
@@ -547,8 +547,12 @@ export class StackConverter extends ArtifactConverter implements intrinsics.Intr
                 return intrinsics.fnIf.evaluate(this, params);
             }
 
+            case 'Fn::Or': {
+                return intrinsics.fnOr.evaluate(this, params);
+            }
+
             default:
-                throw new Error(`unsupported intrinsic function^^ ${fn} (params: ${JSON.stringify(params)})`);
+                throw new Error(`unsupported intrinsic function ${fn} (params: ${JSON.stringify(params)})`);
         }
     }
 

--- a/src/converters/intrinsics.ts
+++ b/src/converters/intrinsics.ts
@@ -25,7 +25,18 @@ import * as equal from 'fast-deep-equal';
  * @internal
  */
 export interface Intrinsic {
+    /**
+     * The name of the intrinsic function such as 'Fn::If'.
+     */
     name: string;
+
+    /**
+     * Executes the logic to evaluate CF expressions and compute the result.
+     *
+     * Most intrinsics need to use IntrinsicContext.evaluate right away to find the values of parameters before
+     * processing them. Conditional intrinsics such as 'Fn::If' or 'Fn::Or' are an exception to this and need to
+     * evaluate their parameters only when necessary.
+     */
     evaluate(ctx: IntrinsicContext, params: Expression[]): Result<any>;
 }
 

--- a/src/converters/intrinsics.ts
+++ b/src/converters/intrinsics.ts
@@ -47,6 +47,7 @@ export interface Expression {}
  *
  * @internal
  */
+// eslint-disable-next-line
 export interface Result<T> {}
 
 /**
@@ -155,7 +156,7 @@ export const fnEquals: Intrinsic = {
  * Recognize forms such as {"Condition" : "SomeOtherCondition"}. If recognized, returns the conditionName.
  */
 function parseConditionExpr(raw: Expression): string|undefined {
-    if (typeof raw !== 'object' || !raw.hasOwnProperty('Condition')) {
+    if (typeof raw !== 'object' || !('Condition' in raw)) {
         return undefined;
     }
     const cond = (<any>raw)['Condition'];

--- a/src/converters/intrinsics.ts
+++ b/src/converters/intrinsics.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as equal from 'fast-deep-equal';
+
 /**
  * Models a CF Intrinsic Function.
  *
@@ -121,6 +123,31 @@ export const fnOr: Intrinsic = {
             }
         })
         return params.reduce(reducer, ctx.succeed(false));
+    }
+}
+
+/**
+ * From the docs: Compares if two values are equal. Returns true if the two values are equal or false if they aren't.
+ *
+ * Fn::Equals: [value_1, value_2]
+ *
+ * See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html#intrinsic-function-reference-conditions-not
+ *
+ */
+export const fnEquals: Intrinsic = {
+    name: 'Fn::Equals',
+    evaluate: (ctx: IntrinsicContext, params: Expression[]): Result<any> => {
+        if (params.length != 2) {
+            return ctx.fail(`Fn::Equals expects exactly 2 params, got ${params.length}`)
+        }
+        return ctx.apply(ctx.evaluate(params[0]), x =>
+            ctx.apply(ctx.evaluate(params[1]), y => {
+                if (equal(x, y)) {
+                    return ctx.succeed(true);
+                } else {
+                    return ctx.succeed(false);
+                }
+            }));
     }
 }
 

--- a/src/converters/intrinsics.ts
+++ b/src/converters/intrinsics.ts
@@ -221,7 +221,8 @@ export const fnNot: Intrinsic = {
         if (params.length != 1) {
             return ctx.fail(`Fn::Not expects exactly 1 param, got ${params.length}`)
         }
-        return ctx.apply(mustBeBoolean(ctx, ctx.evaluate(params[0])), v => ctx.succeed(!v));
+        const x = evaluateConditionSubExpression(ctx, params[0]);
+        return ctx.apply(x, v => ctx.succeed(!v));
     }
 }
 

--- a/src/converters/intrinsics.ts
+++ b/src/converters/intrinsics.ts
@@ -120,7 +120,7 @@ export const fnOr: Intrinsic = {
                 return evaluateConditionOrExpression(ctx, expr);
             }
         })
-        return params.reduce(reducer, ctx.succeed(true));
+        return params.reduce(reducer, ctx.succeed(false));
     }
 }
 

--- a/src/converters/intrinsics.ts
+++ b/src/converters/intrinsics.ts
@@ -1,0 +1,108 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Models a CF Intrinsic Function.
+ *
+ * CloudFormation (CF) intrinsic functions need to be implemented for @pulumi/pulumi-cdk since CDK may emit them in the
+ * synthesized CF template.
+ *
+ * See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html
+ *
+ * @internal
+ */
+interface Intrinsic {
+    name: string;
+    evaluate(ctx: IntrinsicContext, params: Expression[]): Result<any>;
+}
+
+/**
+ * Models a CF expression. Currently this is just "any" but eventually adding more structure and a separate
+ * parse/evaluate steps can help keeping the error messages tractable.
+ *
+ * See also CfnParse for inspiration:
+ *
+ * https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/core/lib/helpers-internal/cfn-parse.ts#L347
+ *
+ * @internal
+ */
+export interface Expression {}
+
+/**
+ * Production code may have intermediate values wrapped in pulumi.Output<T>; this is currently somewhat difficult to test, so
+ * the essentials of pulumi.Output<T> are abstracted into a Result<T>.
+ *
+ * @internal
+ */
+export interface Result<T> {
+    apply<R>(f: (x: T) => Result<R>): Result<R>;
+}
+
+/**
+ * Context available when evaluating CF expressions.
+ *
+ * @internal
+ */
+export interface IntrinsicContext {
+    findCondition(conditionName: string): Expression|undefined;
+    evaluate(expression: Expression): Result<any>;
+    fail(msg: string): Result<any>;
+    succeed<T>(r: T): Result<T>;
+}
+
+/**
+ * "Fn::If": [condition_name, value_if_true, value_if_false]
+ *
+ * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html#intrinsic-function-reference-conditions-i
+ *
+ * @internal
+ */
+export const fnIf: Intrinsic = {
+    name: "Fn::If",
+    evaluate: (ctx: IntrinsicContext, params: Expression[]): Result<any> => {
+        if (params.length !== 3) {
+            return ctx.fail(`Expected 3 parameters, got ${ params.length }`);
+        }
+
+        if (typeof params[0] !== 'string') {
+            return ctx.fail("Expected the first parameter to be a condition name string literal");
+        }
+
+        const conditionName: string = params[0];
+        const exprIfTrue = params[1];
+        const exprIfFalse = params[2];
+
+        return evaluateCondition(ctx, conditionName).apply(ok => {
+            if (ok) {
+                return ctx.evaluate(exprIfTrue);
+            } else {
+                return ctx.evaluate(exprIfFalse);
+            }
+        });
+    }
+}
+
+function evaluateCondition(ctx: IntrinsicContext, conditionName: string): Result<boolean> {
+    const conditionExpr = ctx.findCondition(conditionName);
+    if (conditionExpr === undefined) {
+        return ctx.fail(`No condition "${conditionName}" found`);
+    }
+    return ctx.evaluate(conditionExpr).apply(result => {
+        if (typeof result === 'boolean') {
+            return ctx.succeed(result);
+        } else {
+            return ctx.fail(`Expected condition "${conditionName}" to evaluate to a boolean, got ${typeof(result)}`)
+        }
+    });
+}

--- a/src/converters/intrinsics.ts
+++ b/src/converters/intrinsics.ts
@@ -64,13 +64,42 @@ export interface Result<T> {}
 /**
  * Context available when evaluating CF expressions.
  *
+ * Note that `succeed`, `fail`, `apply` and `Result` expressions are abstracting the use of `pulumi.Input` to facilitate
+ * testing over a simpler structure without dealing with async evaluation.
+ *
  * @internal
  */
 export interface IntrinsicContext {
+
+    /**
+     * Lookup a CF Condition by its logical ID.
+     *
+     * If the condition is found, return the CF Expression with intrinsic function calls inside.
+     *
+     * See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/conditions-section-structure.html
+     */
     findCondition(conditionName: string): Expression|undefined;
+
+    /**
+     * Finds the value of a CF expression evaluating any intrinsic functions or references within.
+     */
     evaluate(expression: Expression): Result<any>;
+
+    /**
+     * If result succeeds, use its value to call `fn` and proceed with what it returns.
+     *
+     * If result fails, do not call `fn` and proceed with the error message from `result`.
+     */
     apply<T,U>(result: Result<T>, fn: (value: U) => Result<U>): Result<U>;
+
+    /**
+     * Fail with a given error message.
+     */
     fail(msg: string): Result<any>;
+
+    /**
+     * Succeed with a given value.
+     */
     succeed<T>(r: T): Result<T>;
 }
 

--- a/tests/converters/intrinsics.test.ts
+++ b/tests/converters/intrinsics.test.ts
@@ -64,6 +64,37 @@ describe('Fn::Or', () => {
     });
 })
 
+describe('Fn::Equals', () => {
+    test('detects equal strings', async () => {
+        const tc = new TestContext({});
+        const result = runIntrinsic(intrinsics.fnEquals, tc, ['a', 'a']);
+        expect(result).toEqual(ok(true));
+    });
+
+    test('detects unequal strings', async () => {
+        const tc = new TestContext({});
+        const result = runIntrinsic(intrinsics.fnEquals, tc, ['a', 'b']);
+        expect(result).toEqual(ok(false));
+    });
+
+    test('detects equal objects', async () => {
+        const tc = new TestContext({});
+        const result = runIntrinsic(intrinsics.fnEquals, tc, [{x: 'a'}, {'x': 'a'}]);
+        expect(result).toEqual(ok(true));
+    });
+
+    test('detects unequal objects', async () => {
+        const tc = new TestContext({});
+        const result = runIntrinsic(intrinsics.fnEquals, tc, [{x: 'a'}, {'x': 'b'}]);
+        expect(result).toEqual(ok(false));
+    });
+
+    test('insists on two arguments', async () => {
+        const tc = new TestContext({});
+        const result = runIntrinsic(intrinsics.fnEquals, tc, [1]);
+        expect(result).toEqual(failed(`Fn::Equals expects exactly 2 params, got 1`));
+    });
+})
 
 function runIntrinsic(fn: intrinsics.Intrinsic, tc: TestContext, args: intrinsics.Expression[]): TestResult<any> {
     const result: TestResult<any> = <any>(fn.evaluate(tc, args));

--- a/tests/converters/intrinsics.test.ts
+++ b/tests/converters/intrinsics.test.ts
@@ -1,0 +1,86 @@
+import * as intrinsics from '../../src/converters/intrinsics';
+
+describe('Fn::If', () => {
+    test('picks true', async () => {
+        const tc = new TestContext({conditions: {'MyCondition': true}});
+        const result = intrinsics.fnIf.evaluate(tc, ['MyCondition', 'yes', 'no']);
+        expect(result).toEqual(new TestSuccessResult<any>('yes'));
+    });
+
+    test('picks false', async () => {
+        const tc = new TestContext({conditions: {'MyCondition': false}});
+        const result = intrinsics.fnIf.evaluate(tc, ['MyCondition', 'yes', 'no']);
+        expect(result).toEqual(new TestSuccessResult<any>('no'));
+    });
+
+    test('errors if condition is not found', async () => {
+        const tc = new TestContext({});
+        const result = intrinsics.fnIf.evaluate(tc, ['MyCondition', 'yes', 'no']);
+        expect(result).toEqual(new TestFailureResult<any>(`No condition "MyCondition" found`));
+    });
+
+    test('errors if condition evaluates to a non-boolean', async () => {
+        const tc = new TestContext({conditions: {'MyCondition': 'OOPS'}});
+        const result = intrinsics.fnIf.evaluate(tc, ['MyCondition', 'yes', 'no']);
+        expect(result).toEqual(new TestFailureResult<any>(`Expected condition \"MyCondition\" to evaluate to a boolean, got string`));
+    });
+});
+
+class TestSuccessResult<T> implements intrinsics.Result<T> {
+    state: 'success';
+    value: T;
+
+    constructor(value: T) {
+        this.state = 'success';
+        this.value = value;
+    }
+
+    apply<R>(f: (x: T) => intrinsics.Result<R>): intrinsics.Result<R> {
+        return f(this.value);
+    }
+};
+
+class TestFailureResult<T> implements intrinsics.Result<T> {
+    state: 'failure';
+    message: string;
+
+    constructor(message: string) {
+        this.state = 'failure';
+        this.message = message;
+    }
+
+    apply<R>(_: (x: T) => intrinsics.Result<R>): intrinsics.Result<R> {
+        return new TestFailureResult<R>(this.message);
+    }
+}
+
+class TestContext implements intrinsics.IntrinsicContext {
+    conditions: { [id: string]: intrinsics.Expression };
+
+    constructor(args: {conditions?: { [id: string]: intrinsics.Expression }}) {
+        if (args.conditions) {
+            this.conditions = args.conditions;
+        } else {
+            this.conditions = {};
+        }
+    }
+
+    findCondition(conditionName: string): intrinsics.Expression|undefined {
+        if (this.conditions.hasOwnProperty(conditionName)) {
+            return this.conditions[conditionName];
+        }
+    }
+
+    evaluate(expression: intrinsics.Expression): intrinsics.Result<any> {
+        // Self-evaluate the expression. This is very incomplete.
+        return new TestSuccessResult<any>(expression);
+    }
+
+    fail(msg: string): intrinsics.Result<any> {
+        return new TestFailureResult<any>(msg);
+    }
+
+    succeed<T>(r: T): intrinsics.Result<T> {
+        return new TestSuccessResult<T>(r);
+    }
+}

--- a/tests/converters/intrinsics.test.ts
+++ b/tests/converters/intrinsics.test.ts
@@ -64,6 +64,77 @@ describe('Fn::Or', () => {
     });
 })
 
+describe('Fn::And', () => {
+    test('picks true', async () => {
+        const tc = new TestContext({});
+        const result = runIntrinsic(intrinsics.fnAnd, tc, [true, true, true]);
+        expect(result).toEqual(ok(true));
+    });
+
+    test('picks false', async () => {
+        const tc = new TestContext({});
+        const result = runIntrinsic(intrinsics.fnAnd, tc, [true, false, true]);
+        expect(result).toEqual(ok(false));
+    });
+
+    test('picks true from inner Condition', async () => {
+        const tc = new TestContext({conditions: {'MyCondition': true}});
+        const result = runIntrinsic(intrinsics.fnAnd, tc, [true, {'Condition': 'MyCondition'}]);
+        expect(result).toEqual(ok(true));
+    });
+
+    test('picks false with inner Condition', async () => {
+        const tc = new TestContext({conditions: {'MyCondition': false}});
+        const result = runIntrinsic(intrinsics.fnAnd, tc, [true, {'Condition': 'MyCondition'}]);
+        expect(result).toEqual(ok(false));
+    });
+
+    test('has to have at least two arguments', async () => {
+        const tc = new TestContext({});
+        const result = runIntrinsic(intrinsics.fnAnd, tc, [false]);
+        expect(result).toEqual(failed(`Fn::And expects at least 2 params, got 1`));
+    });
+
+    test('short-cirtcuits evaluation if false is found', async () => {
+        const tc = new TestContext({});
+        const result = runIntrinsic(intrinsics.fnAnd, tc, [false, {'Condition': 'DoesNotExist'}]);
+        expect(result).toEqual(ok(false));
+    });
+})
+
+
+describe('Fn::Not', () => {
+    test('inverts false', async () => {
+        const tc = new TestContext({});
+        const result = runIntrinsic(intrinsics.fnNot, tc, [true]);
+        expect(result).toEqual(ok(false));
+    });
+
+    test('inverts true', async () => {
+        const tc = new TestContext({});
+        const result = runIntrinsic(intrinsics.fnNot, tc, [false]);
+        expect(result).toEqual(ok(true));
+    });
+
+    test('inverts a false Condition', async () => {
+        const tc = new TestContext({conditions: {'MyCondition': false}});
+        const result = runIntrinsic(intrinsics.fnNot, tc, [{'Condition': 'MyCondition'}]);
+        expect(result).toEqual(ok(true));
+    });
+
+    test('inverts a true Condition', async () => {
+        const tc = new TestContext({conditions: {'MyCondition': true}});
+        const result = runIntrinsic(intrinsics.fnNot, tc, [{'Condition': 'MyCondition'}]);
+        expect(result).toEqual(ok(false));
+    });
+
+    test('requires a boolean', async () => {
+        const tc = new TestContext({});
+        const result = runIntrinsic(intrinsics.fnNot, tc, ['ok']);
+        expect(result).toEqual(failed(`Expected a boolean, got string`));
+    });
+})
+
 describe('Fn::Equals', () => {
     test('detects equal strings', async () => {
         const tc = new TestContext({});


### PR DESCRIPTION
Support [Condition Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html).

Fixes https://github.com/pulumi/pulumi-cdk/issues/206

With this change, if CDK emits CF templates with Condition Functions, pulumi-cdk evaluates these. This unlocks support for new constructs such as the Kinesis Stream construct.
