### PR TITLE
Enable `autoTrim` behavior by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,34 @@ Try the workshop at https://apprunnerworkshop.com
 Read the docs at https://docs.aws.amazon.com/apprunner
 ```
 
+## AWS Cloud Control AutoNaming Config
+
+Sometimes CDK constructs can create resource names that are too long for the
+[AWS Cloud Control provider](https://www.pulumi.com/registry/packages/aws-native/).
+When this happens you can configure the `autoTrim` feature to have the generated
+names be automatically trimmed to fit within the name requirements. If you are
+not configuring your own `aws-native` provider then this feature is enabled by
+default. If you _are_ configuring your own `aws-native` provider then you will
+have to enable this.
+
+```ts
+const nativeProvider = new aws_native.Provider('cdk-native-provider', {
+  region: 'us-east-2',
+  autoNaming: {
+    autoTrim: true,
+    randomSuffixMinLength: 7,
+  },
+});
+const app = new pulumicdk.App('app', (scope: pulumicdk.App): pulumicdk.AppOutputs => {
+    const stack = new AppRunnerStack('teststack');
+    return {
+        url: stack.url,
+    };
+}, {
+  providers: [ nativeProvider ],
+});
+```
+
 ## Bootstrapping
 
 CDK has the concept of [bootstrapping](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html)

--- a/examples/alb/index.ts
+++ b/examples/alb/index.ts
@@ -3,7 +3,6 @@ import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import * as pulumi from '@pulumi/pulumi';
 import * as pulumicdk from '@pulumi/cdk';
-import { CfnOutput } from 'aws-cdk-lib';
 
 class AlbStack extends pulumicdk.Stack {
     url: pulumi.Output<string>;
@@ -28,14 +27,10 @@ class AlbStack extends pulumicdk.Stack {
             port: 80,
         });
 
-        const tg = listener.addTargets('Target', {
+        listener.addTargets('Target', {
             port: 80,
             targets: [asg],
         });
-
-        // workaround for https://github.com/pulumi/pulumi-cdk/issues/62
-        const cfnTargetGroup = tg.node.defaultChild as elbv2.CfnTargetGroup;
-        cfnTargetGroup.overrideLogicalId('LBListenerTG');
 
         listener.connections.allowDefaultPortFromAnyIpv4('Open to the world');
 

--- a/integration/apigateway/sfn-api.ts
+++ b/integration/apigateway/sfn-api.ts
@@ -1,4 +1,3 @@
-import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
 import * as apigw from 'aws-cdk-lib/aws-apigateway';
@@ -15,13 +14,8 @@ export class SfnApi extends Construct {
             stateMachineType: sfn.StateMachineType.EXPRESS,
         });
 
-        // TODO[pulumi/pulumi-cdk#62] The auto created role has too long name
-        const role = new iam.Role(this, 'StartRole', {
-            assumedBy: new iam.ServicePrincipal('apigateway.amazonaws.com'),
-        });
         const api = new apigw.StepFunctionsRestApi(this, 'StepFunctionsRestApi', {
             deploy: false,
-            role,
             stateMachine: stateMachine,
             headers: true,
             path: false,

--- a/integration/examples_nodejs_test.go
+++ b/integration/examples_nodejs_test.go
@@ -148,8 +148,6 @@ func TestCustomResource(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "custom-resource"),
-			// Workaround until TODO[pulumi/pulumi-aws-native#1816] is resolved.
-			Env: []string{"PULUMI_CDK_EXPERIMENTAL_MAX_NAME_LENGTH=56"},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				t.Logf("Outputs: %v", stack.Outputs)
 				url := stack.Outputs["websiteUrl"].(string)

--- a/src/cfn-resource-mappings.ts
+++ b/src/cfn-resource-mappings.ts
@@ -117,18 +117,7 @@ export function mapToCfnResource(
             const pType = pulumiTypeName(typeName);
             const awsModule = aws as any;
 
-            // Workaround until TODO[pulumi/pulumi-aws-native#1816] is resolved.
-            // Not expected to be exposed to users
-            let name = logicalId;
-            const maxNameLength = process.env.PULUMI_CDK_EXPERIMENTAL_MAX_NAME_LENGTH;
-            if (maxNameLength) {
-                const maxLength = parseInt(maxNameLength, 10);
-                if (name.length > maxLength) {
-                    name = name.substring(0, maxLength);
-                }
-            }
-
-            return new awsModule[mName][pType](name, props, options);
+            return new awsModule[mName][pType](logicalId, props, options);
         }
     }
 }

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -20,6 +20,13 @@ import { Vpc } from 'aws-cdk-lib/aws-ec2';
 import { aws_ssm } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
+beforeAll(() => {
+    process.env.AWS_REGION = 'us-east-2';
+});
+afterAll(() => {
+    process.env.AWS_REGION = undefined;
+});
+
 describe('Basic tests', () => {
     setMocks();
     test('Checking single resource registration', async () => {

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import * as pulumi from '@pulumi/pulumi';
+import * as aws from '@pulumi/aws';
+import * as native from '@pulumi/aws-native';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as output from '../src/output';
 import { setMocks, testApp } from './mocks';
@@ -28,14 +30,15 @@ afterAll(() => {
 });
 
 describe('Basic tests', () => {
-    setMocks();
     test('Checking single resource registration', async () => {
+        setMocks();
         await testApp((scope: Construct) => {
             new s3.Bucket(scope, 'MyFirstBucket', { versioned: true });
         });
     });
 
     test('LoadBalancer dnsName attribute does not throw', async () => {
+        setMocks();
         await testApp((scope: Construct) => {
             const vpc = new Vpc(scope, 'vpc');
             const alb = new ApplicationLoadBalancer(scope, 'alb', {
@@ -51,9 +54,163 @@ describe('Basic tests', () => {
         });
     });
     test('Supports Output<T>', async () => {
+        setMocks();
         const o = pulumi.output('the-bucket-name');
         await testApp((scope: Construct) => {
             new s3.Bucket(scope, 'MyFirstBucket', { bucketName: output.asString(o) });
         });
+    });
+
+    test('Creates native provider by default', async () => {
+        const resources: pulumi.runtime.MockResourceArgs[] = [];
+        setMocks(resources);
+        await testApp((scope: Construct) => {
+            new s3.Bucket(scope, 'MyFirstBucket', { versioned: true });
+        });
+        const providers = resources.filter((r) => r.type === 'pulumi:providers:aws-native');
+        expect(providers).toHaveLength(1);
+        expect(providers[0]).toEqual(
+            expect.objectContaining({
+                inputs: {
+                    autoNaming: '{"randomSuffixMinLength":7,"autoTrim":true}',
+                    region: 'us-east-2',
+                    skipCredentialsValidation: 'true',
+                    skipGetEc2Platforms: 'true',
+                    skipMetadataApiCheck: 'true',
+                    skipRegionValidation: 'true',
+                },
+                name: 'cdk-aws-native',
+                provider: '',
+                type: 'pulumi:providers:aws-native',
+            }),
+        );
+    });
+
+    test('Creates native provider when classic provided', async () => {
+        const resources: pulumi.runtime.MockResourceArgs[] = [];
+        setMocks(resources);
+        await testApp(
+            (scope: Construct) => {
+                new s3.Bucket(scope, 'MyFirstBucket', { versioned: true });
+            },
+            {
+                providers: [new aws.Provider('test-aws', {})],
+            },
+        );
+        const providers = resources.filter((r) => r.type === 'pulumi:providers:aws-native');
+        expect(providers).toHaveLength(1);
+        expect(providers[0]).toEqual(
+            expect.objectContaining({
+                inputs: {
+                    autoNaming: '{"randomSuffixMinLength":7,"autoTrim":true}',
+                    region: 'us-east-2',
+                    skipCredentialsValidation: 'true',
+                    skipGetEc2Platforms: 'true',
+                    skipMetadataApiCheck: 'true',
+                    skipRegionValidation: 'true',
+                },
+                name: 'cdk-aws-native',
+                provider: '',
+                type: 'pulumi:providers:aws-native',
+            }),
+        );
+    });
+
+    test('Creates native provider when classic provided object', async () => {
+        const resources: pulumi.runtime.MockResourceArgs[] = [];
+        setMocks(resources);
+        await testApp(
+            (scope: Construct) => {
+                new s3.Bucket(scope, 'MyFirstBucket', { versioned: true });
+            },
+            {
+                providers: {
+                    aws: new aws.Provider('test-aws', {}),
+                },
+            },
+        );
+        const providers = resources.filter((r) => r.type === 'pulumi:providers:aws-native');
+        expect(providers).toHaveLength(1);
+        expect(providers[0]).toEqual(
+            expect.objectContaining({
+                inputs: {
+                    autoNaming: '{"randomSuffixMinLength":7,"autoTrim":true}',
+                    region: 'us-east-2',
+                    skipCredentialsValidation: 'true',
+                    skipGetEc2Platforms: 'true',
+                    skipMetadataApiCheck: 'true',
+                    skipRegionValidation: 'true',
+                },
+                name: 'cdk-aws-native',
+                provider: '',
+                type: 'pulumi:providers:aws-native',
+            }),
+        );
+    });
+
+    test('does not create native provider when one is provided', async () => {
+        const resources: pulumi.runtime.MockResourceArgs[] = [];
+        setMocks(resources);
+        await testApp(
+            (scope: Construct) => {
+                new s3.Bucket(scope, 'MyFirstBucket', { versioned: true });
+            },
+            {
+                providers: [
+                    new native.Provider('test-native', {
+                        region: 'us-west-2',
+                    }),
+                ],
+            },
+        );
+        const providers = resources.filter((r) => r.type === 'pulumi:providers:aws-native');
+        expect(providers).toHaveLength(1);
+        expect(providers[0]).toEqual(
+            expect.objectContaining({
+                inputs: {
+                    region: 'us-west-2',
+                    skipCredentialsValidation: 'true',
+                    skipGetEc2Platforms: 'true',
+                    skipMetadataApiCheck: 'true',
+                    skipRegionValidation: 'true',
+                },
+                name: 'test-native',
+                provider: '',
+                type: 'pulumi:providers:aws-native',
+            }),
+        );
+    });
+
+    test('does not create native provider when one is provided object', async () => {
+        const resources: pulumi.runtime.MockResourceArgs[] = [];
+        setMocks(resources);
+        await testApp(
+            (scope: Construct) => {
+                new s3.Bucket(scope, 'MyFirstBucket', { versioned: true });
+            },
+            {
+                providers: {
+                    'aws-native': new native.Provider('test-native', {
+                        region: 'us-west-2',
+                    }),
+                },
+            },
+        );
+        const providers = resources.filter((r) => r.type === 'pulumi:providers:aws-native');
+        expect(providers).toHaveLength(1);
+        expect(providers[0]).toEqual(
+            expect.objectContaining({
+                inputs: {
+                    region: 'us-west-2',
+                    skipCredentialsValidation: 'true',
+                    skipGetEc2Platforms: 'true',
+                    skipMetadataApiCheck: 'true',
+                    skipRegionValidation: 'true',
+                },
+                name: 'test-native',
+                provider: '',
+                type: 'pulumi:providers:aws-native',
+            }),
+        );
     });
 });

--- a/tests/cdk-resource.test.ts
+++ b/tests/cdk-resource.test.ts
@@ -13,8 +13,12 @@ import { Construct } from 'constructs';
 describe('CDK Construct tests', () => {
     let resources: MockResourceArgs[] = [];
     beforeAll(() => {
+        process.env.AWS_REGION = 'us-east-2';
         resources = [];
         setMocks(resources);
+    });
+    afterAll(() => {
+        process.env.AWS_REGION = undefined;
     });
     // DynamoDB table was previously mapped to the `aws` provider
     // otherwise this level of testing wouldn't be necessary.

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -1,6 +1,13 @@
 import * as pulumi from '@pulumi/pulumi';
 import { CdkConstruct } from '../src/interop';
-import { Stack as CdkStack, DockerImageAssetLocation, DockerImageAssetSource, FileAssetLocation, FileAssetSource, ISynthesisSession } from 'aws-cdk-lib/core';
+import {
+    Stack as CdkStack,
+    DockerImageAssetLocation,
+    DockerImageAssetSource,
+    FileAssetLocation,
+    FileAssetSource,
+    ISynthesisSession,
+} from 'aws-cdk-lib/core';
 import { AppComponent, AppOptions } from '../src/types';
 import { MockCallArgs, MockResourceArgs } from '@pulumi/pulumi/runtime';
 import { Construct } from 'constructs';
@@ -28,7 +35,7 @@ export class MockAppComponent extends pulumi.ComponentResource implements AppCom
     }
 }
 
-export async function testApp(fn: (scope: Construct) => void) {
+export async function testApp(fn: (scope: Construct) => void, options?: pulumi.ComponentResourceOptions) {
     class TestStack extends Stack {
         constructor(app: App, id: string) {
             super(app, id, {
@@ -48,9 +55,15 @@ export async function testApp(fn: (scope: Construct) => void) {
         }
     }
 
-    const app = new App('testapp', (scope: App) => {
-        new TestStack(scope, 'teststack');
-    });
+    const app = new App(
+        'testapp',
+        (scope: App) => {
+            new TestStack(scope, 'teststack');
+        },
+        {
+            ...options,
+        },
+    );
     const converter = await app.converter;
     await Promise.all(
         Array.from(converter.stacks.values()).flatMap((stackConverter) => {
@@ -151,8 +164,8 @@ export function setMocks(resources?: MockResourceArgs[]) {
                             ...args.inputs,
                             id: args.inputs.logicalId + '_id',
                             data: {
-                                "DestinationBucketArn": `arn:aws:s3:::${args.inputs.bucketName}`
-                            }
+                                DestinationBucketArn: `arn:aws:s3:::${args.inputs.bucketName}`,
+                            },
                         },
                     };
                 default:
@@ -173,7 +186,6 @@ export function setMocks(resources?: MockResourceArgs[]) {
 }
 
 export class MockSynth extends PulumiSynthesizerBase {
-
     constructor(readonly bucket: string, readonly prefix: string) {
         super();
     }
@@ -195,4 +207,3 @@ export class MockSynth extends PulumiSynthesizerBase {
         throw new Error('Method not implemented.');
     }
 }
-

--- a/tests/synthesizer.test.ts
+++ b/tests/synthesizer.test.ts
@@ -7,6 +7,13 @@ import { asNetworkMode, asPlatforms } from '../src/synthesizer';
 import { NetworkMode, Platform as DockerPlatform } from '@pulumi/docker-build';
 import { DockerImageAsset, Platform, NetworkMode as Network } from 'aws-cdk-lib/aws-ecr-assets';
 
+beforeAll(() => {
+    process.env.AWS_REGION = 'us-east-2';
+});
+afterAll(() => {
+    process.env.AWS_REGION = undefined;
+});
+
 describe('Synthesizer File Assets', () => {
     test('no assets = no staging resources', async () => {
         const resources: MockResourceArgs[] = [];
@@ -16,6 +23,19 @@ describe('Synthesizer File Assets', () => {
             new CfnBucket(scope, 'Bucket');
         });
         expect(resources).toEqual([
+            expect.objectContaining({
+                inputs: {
+                    autoNaming: '{"randomSuffixMinLength":7,"autoTrim":true}',
+                    region: 'us-east-2',
+                    skipCredentialsValidation: 'true',
+                    skipGetEc2Platforms: 'true',
+                    skipMetadataApiCheck: 'true',
+                    skipRegionValidation: 'true',
+                },
+                name: 'cdk-aws-native',
+                provider: '',
+                type: 'pulumi:providers:aws-native',
+            }),
             expect.objectContaining({
                 name: 'staging-stack-project-stack',
                 type: 'cdk:construct:StagingStack',


### PR DESCRIPTION
This PR enables the aws-native `AutoNaming.autoTrim` feature by default.
It does this by creating an aws-native provider by default if the user
does not provide one.

I've updated tests to remove the workarounds.

**Alternatives**

1. We could require that the user configure this themselves.
2. Is there a way to set config values programatically?

closes #62, closes #70