### PR TITLE
chore: fix all lint warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,9 @@ module.exports = {
   rules: {
     // disabling this since it is used everywhere in this repo
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-unused-vars": "warn"
+    "@typescript-eslint/no-unused-vars": ["warn", {
+        "varsIgnorePattern": "^[_]",
+        "argsIgnorePattern": "^[_]"
+    }]
   }
 };

--- a/src/converters/app-converter.ts
+++ b/src/converters/app-converter.ts
@@ -18,7 +18,7 @@ import {
 } from '@pulumi/aws-native';
 import { mapToAwsResource } from '../aws-resource-mappings';
 import { attributePropertyName, mapToCfnResource } from '../cfn-resource-mappings';
-import { CloudFormationMapping, CloudFormationResource, getDependsOn } from '../cfn';
+import { CloudFormationResource, getDependsOn } from '../cfn';
 import { OutputMap, OutputRepr } from '../output-map';
 import { parseSub } from '../sub';
 import { getPartition } from '@pulumi/aws-native/getPartition';
@@ -475,7 +475,7 @@ export class StackConverter extends ArtifactConverter {
 
             case 'Fn::Sub':
                 return lift((params) => {
-                    const [template, vars] =
+                    const [template, _vars] =
                         typeof params === 'string' ? [params, undefined] : [params[0] as string, params[1]];
 
                     const parts: string[] = [];


### PR DESCRIPTION
A combination of fixes and relaxed linter rules, `yarn run lint` now passes without warnings.