### PR TITLE
Validate all CDK resources are mapped to Pulumi resources

### DIFF
--- a/src/assembly/stack.ts
+++ b/src/assembly/stack.ts
@@ -107,7 +107,7 @@ export class StackManifest {
     /**
      * Map of resource logicalId to CloudFormation template resource fragment
      */
-    private readonly resources: { [logicalId: string]: CloudFormationResource };
+    public readonly resources: { [logicalId: string]: CloudFormationResource };
 
     /**
      * The Mappings from the CFN Stack


### PR DESCRIPTION
Previously we didn't ensure that all CDK resources were actually mapped to Pulumi resources.
While working on adding support for Custom Resources we noticed that some resources were not mapped (e.g. resources with ID of 'Default').

This change adds validation to the GraphBuilder in order to ensure that all resources are mapped.
In order to prevent any unexpected behavior we're failing hard if we do not detect that all resources are mapped.

Closes https://github.com/pulumi/pulumi-cdk/issues/186