### PR TITLE
chore: add api-docs auto generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,150 +146,19 @@ create the following staging resources.
 5. [aws.s3.BucketPolicy](https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucketpolicy/)
   - Require SSL
 
+### ECR Resources
+
+When any image assets are added to your application, CDK will automatically
+create the following staging resources.
+
+1. `aws.ecr.Repository`
+  - `imageTagMutability`: `IMMUTABLE`
+2. `aws.ecr.LifecyclePolicy`
+  - Expire old images when the number of images > 3
+
 ## API
 
-### `App`
-
-A Pulumi CDK App component. This is the entrypoint to your Pulumi CDK application.
-In order to deploy a CDK application with Pulumi, you must start with this class.
-
-#### `constructor`
-
-Create and register an AWS CDK app deployed with Pulumi.
-
-```ts
-constructor(id: string, createFunc: (scope: App) => void | AppOutputs, props?: AppResourceOptions)
-```
-
-Parameters:
-* `id`: The _unique_ name of the app
-* `createFunc`: A callback function where all CDK Stacks must be created
-* `options`: A bag of options that control the resource's behavior
-
-#### `outputs`
-
-The collection of outputs from the Pulumi CDK App represented as Pulumi Outputs.
-Each `CfnOutput` defined in each AWS CDK Stack will populate a value in the
-outputs.
-
-```ts
-outputs: { [outputId: string]: pulumi.Output<any> }
-```
-
-#### `AppResourceOptions`
-
-Options specific to the App Component
-
-```ts
-interface AppResourceOptions
-```
-
-#### `remapCloudControlResource`
-
-This optional method can be implemented to define a mapping to override and/or
-provide an implementation for a CloudFormation resource type that is not (yet)
-implemented in the AWS Cloud Control API (and thus not yet available in the
-Pulumi AWS Native provider). Pulumi code can override this method to provide a
-custom mapping of CloudFormation elements and their properties into Pulumi
-CustomResources, commonly by using the AWS Classic provider to implement the
-missing resource.
-
-```ts
-remapCloudControlResource(logicalId: string, typeName: string, props: any, options: pulumi.ResourceOptions): ResourceMapping | undefined;
-```
-
-Parameters:
-* `logicalId`: The logical ID of the resource being mapped.
-* `typeName`: The CloudFormation type name of the resource being mapped.
-* `props`: The bag of input properties to the CloudFormation resource being mapped.
-* `options`: The set of Pulumi ResourceOptions to apply to the resource being mapped.
-
-Returns an object containing one or more logical IDs mapped to Pulumi resources
-that must be created to implement the mapped CloudFormation resource, or else
-undefined if no mapping is implemented.
-
-#### `appId`
-
-This is a unique identifier for the application. It will be used in the names of the
-staging resources created for the application. This `appId` should be unique across apps.
-
-### `Stack`
-
-A Construct that represents an AWS CDK stack deployed with Pulumi. In order to
-deploy a CDK stack with Pulumi, it must derive from this class.
-
-#### `constructor`
-
-Create and register an AWS CDK stack deployed with Pulumi.
-
-```ts
-constructor(app: App, name: string, options?: StackOptions)
-```
-
-Parameters:
-* `app`: The Pulumi CDK App
-* `name`: The _unique_ name of the resource.
-* `options`: A bag of options that control this resource's behavior.
-
-
-#### `asOutput`
-
-Convert a CDK value to a Pulumi output.
-
-Parameters:
-* `v`: A CDK value.
-
-```ts
-asOutput<T>(v: T): pulumi.Output<T>
-```
-
-### `StackOptions`
-
-Options specific to the Stack component.
-
-```ts
-interface StackOptions
-```
-
-
-### `asString`
-
-Convert a Pulumi Output to a CDK string value.
-
-```ts
-function asString<T>(o: pulumi.Output<T>): string
-```
-
-Parameters:
- * `o`: A Pulumi Output value which represents a string.
-
-Returns A CDK token representing a string value.
-
-### `asNumber`
-
-Convert a Pulumi Output to a CDK number value.
-
-```ts
-function asNumber<T>(o: pulumi.Output<T>): number
-```
-
-Parameters:
- * `o`: A Pulumi Output value which represents a number.
-
-Returns A CDK token representing a number value.
-
-### `asList`
-
-Convert a Pulumi Output to a list of CDK values.
-
-```ts
-function asList<T>(o: pulumi.Output<T>): string[]
-```
-
-Parameters:
- * `o`: A Pulumi Output value which represents a list.
-
-Returns a CDK token representing a list of values.
+See [API Docs](./api-docs/README.md) for more details.
 
 ## Building locally
 
@@ -298,7 +167,7 @@ Install dependencies, build library, and link for local usage.
 ```sh
 $ yarn install
 $ yarn build
-$ pushd lib && yarn link && popd
+$ yarn link
 ```
 
 Run unit test:

--- a/api-docs/Namespace.interop.md
+++ b/api-docs/Namespace.interop.md
@@ -1,0 +1,89 @@
+[**@pulumi/cdk**](README.md) • **Docs**
+
+***
+
+[@pulumi/cdk](README.md) / interop
+
+# interop
+
+## Type Aliases
+
+### ResourceAttributeMapping
+
+> **ResourceAttributeMapping**: `object`
+
+Use this type if you need to control the attributes that are available on the
+mapped resource. For example if the CFN resource has an attribute called `resourceArn` and
+the mapped resource only has an attribute called `arn` you can return the extra `resourceArn`
+attribute
+
+#### Type declaration
+
+| Name | Type | Defined in |
+| ------ | ------ | ------ |
+| `attributes`? | `object` | [interop.ts:88](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/interop.ts#L88) |
+| `resource` | `pulumi.Resource` | [interop.ts:87](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/interop.ts#L87) |
+
+#### Example
+
+```ts
+return {
+  resource: mappedResource,
+  attributes: {
+    resourceArn: mappedResource.arn,
+  }
+}
+```
+
+#### Defined in
+
+[interop.ts:86](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/interop.ts#L86)
+
+***
+
+### ResourceAttributeMappingArray
+
+> **ResourceAttributeMappingArray**: [`ResourceAttributeMapping`](Namespace.interop.md#resourceattributemapping) & `object`[]
+
+Use this type if a single CFN resource maps to multiple AWS resources
+
+#### Defined in
+
+[interop.ts:94](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/interop.ts#L94)
+
+***
+
+### ResourceMapping
+
+> **ResourceMapping**: [`ResourceAttributeMapping`](Namespace.interop.md#resourceattributemapping) \| `pulumi.Resource` \| [`ResourceAttributeMappingArray`](Namespace.interop.md#resourceattributemappingarray)
+
+#### Defined in
+
+[interop.ts:96](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/interop.ts#L96)
+
+## Functions
+
+### normalize()
+
+> **normalize**(`value`, `cfnType`?, `pulumiProvider`?): `any`
+
+normalize will take the resource properties for a specific CloudFormation resource and
+will covert those properties to be compatible with Pulumi properties.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `value` | `any` | The resource properties to be normalized |
+| `cfnType`? | `string` | The CloudFormation resource type being normalized (e.g. AWS::S3::Bucket). If no value is provided then property conversion will be done without schema knowledge |
+| `pulumiProvider`? | `PulumiProvider` | The pulumi provider to read the schema from. If `cfnType` is provided then this defaults to PulumiProvider.AWS_NATIVE |
+
+#### Returns
+
+`any`
+
+The normalized resource properties
+
+#### Defined in
+
+[interop.ts:41](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/interop.ts#L41)

--- a/api-docs/Namespace.synthesizer.md
+++ b/api-docs/Namespace.synthesizer.md
@@ -1,0 +1,186 @@
+[**@pulumi/cdk**](README.md) • **Docs**
+
+***
+
+[@pulumi/cdk](README.md) / synthesizer
+
+# synthesizer
+
+## Classes
+
+### PulumiSynthesizer
+
+This is a custom synthesizer that determines how the CDK stack should be synthesized.
+
+In our case, since we can create Pulumi resources directly, we don't need a separate bootstrap step.
+This is very similar to how the AppStagingSynthesizer works, but is simpler because we don't need to
+manage/create a separate CDK stack to manage the resources.
+
+As CDK applications register assets this synthesizer will dynamically create the necessary staging
+resources and deploy the assets themselves.
+
+#### See
+
+ - Recommended reading https://github.com/aws/aws-cdk/wiki/Security-And-Safety-Dev-Guide#controlling-the-permissions-used-by-cdk-deployments
+ - https://docs.aws.amazon.com/cdk/api/v2/docs/app-staging-synthesizer-alpha-readme.html
+
+#### Extends
+
+- [`PulumiSynthesizerBase`](Namespace.synthesizer.md#pulumisynthesizerbase)
+
+#### Implements
+
+- `IReusableStackSynthesizer`
+
+#### Constructors
+
+##### new PulumiSynthesizer()
+
+> **new PulumiSynthesizer**(`props`): [`PulumiSynthesizer`](Namespace.synthesizer.md#pulumisynthesizer)
+
+###### Parameters
+
+| Parameter | Type |
+| ------ | ------ |
+| `props` | [`PulumiSynthesizerOptions`](Namespace.synthesizer.md#pulumisynthesizeroptions) |
+
+###### Returns
+
+[`PulumiSynthesizer`](Namespace.synthesizer.md#pulumisynthesizer)
+
+###### Overrides
+
+[`PulumiSynthesizerBase`](Namespace.synthesizer.md#pulumisynthesizerbase).[`constructor`](Namespace.synthesizer.md#constructors-1)
+
+###### Defined in
+
+[synthesizer.ts:231](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L231)
+
+#### Properties
+
+| Property | Modifier | Type | Default value | Description | Overrides | Defined in |
+| ------ | ------ | ------ | ------ | ------ | ------ | ------ |
+| `stagingBucket?` | `public` | `BucketV2` | `undefined` | The app-scoped, environment-keyed staging bucket. | - | [synthesizer.ts:158](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L158) |
+| `stagingRepos` | `readonly` | `Record`\<`string`, `Repository`\> | `{}` | The app-scoped, environment-keyed ecr repositories associated with this app. | - | [synthesizer.ts:163](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L163) |
+| `stagingStack` | `readonly` | `CdkConstruct` | `undefined` | The Pulumi ComponentResource wrapper which contains all of the staging resources. This can be added to the `dependsOn` of the main stack to ensure the staging assets are created first | [`PulumiSynthesizerBase`](Namespace.synthesizer.md#pulumisynthesizerbase).`stagingStack` | [synthesizer.ts:153](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L153) |
+
+#### Methods
+
+##### getDeployTimePrefix()
+
+> **getDeployTimePrefix**(): `string`
+
+Returns the S3 key prefix that will be used for deploy time assets.
+
+###### Returns
+
+`string`
+
+###### Inherited from
+
+[`PulumiSynthesizerBase`](Namespace.synthesizer.md#pulumisynthesizerbase).[`getDeployTimePrefix`](Namespace.synthesizer.md#getdeploytimeprefix-1)
+
+###### Defined in
+
+[synthesizer.ts:114](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L114)
+
+##### getStagingBucket()
+
+> **getStagingBucket**(): `Input`\<`string`\>
+
+Returns the name of the staging bucket that will be used to store assets
+and custom resource responses.
+
+###### Returns
+
+`Input`\<`string`\>
+
+###### Overrides
+
+[`PulumiSynthesizerBase`](Namespace.synthesizer.md#pulumisynthesizerbase).[`getStagingBucket`](Namespace.synthesizer.md#getstagingbucket-1)
+
+###### Defined in
+
+[synthesizer.ts:437](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L437)
+
+***
+
+### `abstract` PulumiSynthesizerBase
+
+Base Synthesizer class. If you want to implement your own Pulumi Synthesizer which
+creates Pulumi resources then you should extend this class.
+
+#### Extends
+
+- `StackSynthesizer`
+
+#### Extended by
+
+- [`PulumiSynthesizer`](Namespace.synthesizer.md#pulumisynthesizer)
+
+#### Constructors
+
+##### new PulumiSynthesizerBase()
+
+> **new PulumiSynthesizerBase**(): [`PulumiSynthesizerBase`](Namespace.synthesizer.md#pulumisynthesizerbase)
+
+###### Returns
+
+[`PulumiSynthesizerBase`](Namespace.synthesizer.md#pulumisynthesizerbase)
+
+###### Inherited from
+
+`cdk.StackSynthesizer.constructor`
+
+#### Properties
+
+| Property | Modifier | Type | Description | Defined in |
+| ------ | ------ | ------ | ------ | ------ |
+| `stagingStack` | `abstract` | `CdkConstruct` | The Pulumi ComponentResource wrapper which contains all of the staging resources. This can be added to the `dependsOn` of the main stack to ensure the staging assets are created first | [synthesizer.ts:103](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L103) |
+
+#### Methods
+
+##### getDeployTimePrefix()
+
+> **getDeployTimePrefix**(): `string`
+
+Returns the S3 key prefix that will be used for deploy time assets.
+
+###### Returns
+
+`string`
+
+###### Defined in
+
+[synthesizer.ts:114](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L114)
+
+##### getStagingBucket()
+
+> `abstract` **getStagingBucket**(): `Input`\<`string`\>
+
+Returns the name of the staging bucket that will be used to store assets
+and custom resource responses.
+
+###### Returns
+
+`Input`\<`string`\>
+
+###### Defined in
+
+[synthesizer.ts:109](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L109)
+
+## Interfaces
+
+### PulumiSynthesizerOptions
+
+#### Properties
+
+| Property | Modifier | Type | Description | Defined in |
+| ------ | ------ | ------ | ------ | ------ |
+| `appId` | `readonly` | `string` | A unique identifier for the application that the staging stack belongs to. This identifier will be used in the name of staging resources created for this application, and should be unique across CDK apps. The identifier should include lowercase characters, numbers, periods (.) and dashes ('-') only and have a maximum of 17 characters. | [synthesizer.ts:28](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L28) |
+| `autoDeleteStagingAssets?` | `readonly` | `boolean` | Auto deletes objects in the staging S3 bucket and images in the staging ECR repositories. This will also delete the S3 buckets and ECR repositories themselves when all objects / images are removed. **Default** `true` | [synthesizer.ts:73](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L73) |
+| `deployTimeFileAssetLifetime?` | `readonly` | `Duration` | The lifetime for deploy time file assets. Assets that are only necessary at deployment time (for instance, CloudFormation templates and Lambda source code bundles) will be automatically deleted after this many days. Assets that may be read from the staging bucket during your application's run time will not be deleted. Set this to the length of time you wish to be able to roll back to previous versions of your application without having to do a new `cdk synth` and re-upload of assets. **Default** `- Duration.days(30)` | [synthesizer.ts:52](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L52) |
+| `imageAssetVersionCount?` | `readonly` | `number` | The maximum number of image versions to store in a repository. Previous versions of an image can be stored for rollback purposes. Once a repository has more than 3 image versions stored, the oldest version will be discarded. This allows for sensible garbage collection while maintaining a few previous versions for rollback scenarios. **Default** `- up to 3 versions stored` | [synthesizer.ts:85](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L85) |
+| `parent?` | `readonly` | `Resource` | The parent resource for any Pulumi resources created by the Synthesizer | [synthesizer.ts:90](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L90) |
+| `stagingBucketName?` | `readonly` | `string` | Explicit name for the staging bucket **Default** `- a well-known name unique to this app/env.` | [synthesizer.ts:35](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L35) |
+| `stagingStackNamePrefix?` | `readonly` | `string` | Specify a custom prefix to be used as the staging stack name and construct ID. The prefix will be appended before the appId, which is required to be part of the stack name and construct ID to ensure uniqueness. **Default** `'staging-stack'` | [synthesizer.ts:62](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L62) |

--- a/api-docs/README.md
+++ b/api-docs/README.md
@@ -1,0 +1,335 @@
+**@pulumi/cdk** • **Docs**
+
+***
+
+# @pulumi/cdk
+
+## Enumerations
+
+### PulumiProvider
+
+The Pulumi provider to read the schema from
+
+#### Enumeration Members
+
+| Enumeration Member | Value | Defined in |
+| ------ | ------ | ------ |
+| `AWS_NATIVE` | `"aws-native"` | [types.ts:62](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/types.ts#L62) |
+
+## Classes
+
+### App
+
+A Pulumi CDK App component. This is the entrypoint to your Pulumi CDK application.
+The second argument is a callback function where all CDK resources must be created.
+
+#### Example
+
+```ts
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as pulumicdk from '@pulumi/cdk';
+
+const app = new pulumicdk.App('app', (scope: pulumicdk.App): pulumicdk.AppOutputs => {
+  // All resources must be created within a Pulumi Stack
+  const stack = new pulumicdk.Stack(scope, 'pulumi-stack');
+  const bucket = new s3.Bucket(stack, 'my-bucket');
+  return {
+    bucket: stack.asOutput(bucket.bucketName),
+  };
+});
+
+export const bucket = app.outputs['bucket'];
+```
+
+#### Extends
+
+- `ComponentResource`\<`AppResource`\>
+
+#### Implements
+
+- `ICloudAssemblyDirectoryProducer`
+- [`AppComponent`](README.md#appcomponent)
+
+#### Constructors
+
+##### new App()
+
+> **new App**(`id`, `createFunc`, `props`?): [`App`](README.md#app)
+
+###### Parameters
+
+| Parameter | Type |
+| ------ | ------ |
+| `id` | `string` |
+| `createFunc` | (`scope`) => `void` \| [`AppOutputs`](README.md#appoutputs) |
+| `props`? | [`AppResourceOptions`](README.md#appresourceoptions) |
+
+###### Returns
+
+[`App`](README.md#app)
+
+###### Overrides
+
+`pulumi.ComponentResource<AppResource>.constructor`
+
+###### Defined in
+
+[stack.ts:96](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/stack.ts#L96)
+
+#### Properties
+
+| Property | Modifier | Type | Default value | Description | Defined in |
+| ------ | ------ | ------ | ------ | ------ | ------ |
+| `name` | `readonly` | `string` | `undefined` | The name of the component | [stack.ts:55](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/stack.ts#L55) |
+| `outputs` | `public` | `object` | `{}` | The collection of outputs from the AWS CDK Stack represented as Pulumi Outputs. Each CfnOutput defined in the AWS CDK Stack will populate a value in the outputs. | [stack.ts:61](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/stack.ts#L61) |
+
+***
+
+### Stack
+
+A Construct that represents an AWS CDK stack deployed with Pulumi.
+
+In order to deploy a CDK stack with Pulumi, it must derive from this class.
+
+#### Extends
+
+- `Stack`
+
+#### Constructors
+
+##### new Stack()
+
+> **new Stack**(`app`, `name`, `options`?): [`Stack`](README.md#stack)
+
+Create and register an AWS CDK stack deployed with Pulumi.
+
+###### Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `app` | [`App`](README.md#app) | - |
+| `name` | `string` | The _unique_ name of the resource. |
+| `options`? | [`StackOptions`](README.md#stackoptions) | A bag of options that control this resource's behavior. |
+
+###### Returns
+
+[`Stack`](README.md#stack)
+
+###### Overrides
+
+`cdk.Stack.constructor`
+
+###### Defined in
+
+[stack.ts:261](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/stack.ts#L261)
+
+#### Methods
+
+##### asOutput()
+
+> **asOutput**\<`T`\>(`v`): `Output`\<`Unwrap`\<`T`\>\>
+
+Convert a CDK value to a Pulumi Output.
+
+###### Type Parameters
+
+| Type Parameter |
+| ------ |
+| `T` |
+
+###### Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `v` | `T` | A CDK value. |
+
+###### Returns
+
+`Output`\<`Unwrap`\<`T`\>\>
+
+A Pulumi Output value.
+
+###### Defined in
+
+[stack.ts:274](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/stack.ts#L274)
+
+## Interfaces
+
+### AppComponent
+
+AppComponent is the interface representing the Pulumi CDK App Component Resource
+
+#### Properties
+
+| Property | Modifier | Type | Description | Defined in |
+| ------ | ------ | ------ | ------ | ------ |
+| `name` | `readonly` | `string` | The name of the component | [types.ts:72](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/types.ts#L72) |
+
+***
+
+### AppOptions
+
+Options for creating a Pulumi CDK App Component
+
+#### Properties
+
+| Property | Type | Description | Defined in |
+| ------ | ------ | ------ | ------ |
+| `appId?` | `string` | A unique identifier for the application that the asset staging stack belongs to. This identifier will be used in the name of staging resources created for this application, and should be unique across apps. The identifier should include lowercase characters, numbers, periods (.) and dashes ('-') only and have a maximum of 17 characters. **Default** `- generated from the pulumi project and stack name` | [types.ts:25](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/types.ts#L25) |
+| `props?` | `AppProps` | Specify the CDK Stack properties to asociate with the stack. | [types.ts:12](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/types.ts#L12) |
+
+#### Methods
+
+##### remapCloudControlResource()?
+
+> `optional` **remapCloudControlResource**(`logicalId`, `typeName`, `props`, `options`): `undefined` \| [`ResourceMapping`](Namespace.interop.md#resourcemapping)
+
+Defines a mapping to override and/or provide an implementation for a CloudFormation resource
+type that is not (yet) implemented in the AWS Cloud Control API (and thus not yet available in
+the Pulumi AWS Native provider). Pulumi code can override this method to provide a custom mapping
+of CloudFormation elements and their properties into Pulumi CustomResources, commonly by using the
+AWS Classic provider to implement the missing resource.
+
+###### Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `logicalId` | `string` | The logical ID of the resource being mapped. |
+| `typeName` | `string` | The CloudFormation type name of the resource being mapped. |
+| `props` | `any` | The bag of input properties to the CloudFormation resource being mapped. |
+| `options` | `ResourceOptions` | The set of Pulumi ResourceOptions to apply to the resource being mapped. |
+
+###### Returns
+
+`undefined` \| [`ResourceMapping`](Namespace.interop.md#resourcemapping)
+
+An object containing one or more logical IDs mapped to Pulumi resources that must be
+created to implement the mapped CloudFormation resource, or else undefined if no mapping is
+implemented.
+
+###### Defined in
+
+[types.ts:42](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/types.ts#L42)
+
+***
+
+### AppResourceOptions
+
+Options specific to the Pulumi CDK App component.
+
+#### Extends
+
+- `ComponentResourceOptions`
+
+#### Properties
+
+| Property | Type | Defined in |
+| ------ | ------ | ------ |
+| `appOptions?` | [`AppOptions`](README.md#appoptions) | [types.ts:54](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/types.ts#L54) |
+
+***
+
+### StackOptions
+
+Options for creating a Pulumi CDK Stack
+
+#### Extends
+
+- `ComponentResourceOptions`
+
+#### Properties
+
+| Property | Type | Description | Defined in |
+| ------ | ------ | ------ | ------ |
+| `props?` | `StackProps` | The CDK Stack props | [stack.ts:227](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/stack.ts#L227) |
+
+## Type Aliases
+
+### AppOutputs
+
+> **AppOutputs**: `object`
+
+#### Index Signature
+
+ \[`outputId`: `string`\]: `pulumi.Output`\<`any`\>
+
+#### Defined in
+
+[stack.ts:24](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/stack.ts#L24)
+
+## Functions
+
+### asList()
+
+> **asList**(`o`): `string`[]
+
+Convert a Pulumi Output to a list of CDK string values.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `o` | `Output`\<`string`[]\> | A Pulumi Output value which represents a list of strings. |
+
+#### Returns
+
+`string`[]
+
+A CDK token representing a list of string values.
+
+#### Defined in
+
+[output.ts:45](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/output.ts#L45)
+
+***
+
+### asNumber()
+
+> **asNumber**(`o`): `number`
+
+Convert a Pulumi Output to a CDK number value.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `o` | `OutputInstance`\<`number`\> | A Pulumi Output value which represents a number. |
+
+#### Returns
+
+`number`
+
+A CDK token representing a number value.
+
+#### Defined in
+
+[output.ts:35](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/output.ts#L35)
+
+***
+
+### asString()
+
+> **asString**(`o`): `string`
+
+Convert a Pulumi Output to a CDK string value.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `o` | `Output`\<`string`\> | A Pulumi Output value which represents a string. |
+
+#### Returns
+
+`string`
+
+A CDK token representing a string value.
+
+#### Defined in
+
+[output.ts:25](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/output.ts#L25)
+
+## Namespaces
+
+- [interop](Namespace.interop.md)
+- [synthesizer](Namespace.synthesizer.md)

--- a/examples/scalable-webhook/lambda-fns/publish/lambda.ts
+++ b/examples/scalable-webhook/lambda-fns/publish/lambda.ts
@@ -37,4 +37,3 @@ const sendRes = (status: number, body: string) => {
     };
     return response;
 };
-

--- a/examples/scalable-webhook/lambda-fns/subscribe/lambda.ts
+++ b/examples/scalable-webhook/lambda-fns/subscribe/lambda.ts
@@ -28,4 +28,3 @@ export const handler: SQSHandler = async function (event) {
         }
     }
 };
-

--- a/examples/the-big-fan/lambda-fns/subscribe/anyOtherStatus.ts
+++ b/examples/the-big-fan/lambda-fns/subscribe/anyOtherStatus.ts
@@ -8,4 +8,3 @@ export const handler = async function (event: any) {
         console.log('received message ' + payload);
     }
 };
-

--- a/examples/the-big-fan/lambda-fns/subscribe/createdStatus.ts
+++ b/examples/the-big-fan/lambda-fns/subscribe/createdStatus.ts
@@ -8,4 +8,3 @@ export const handler = async function (event: any) {
         console.log('received message ' + payload);
     }
 };
-

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "prettier": "^2.6.2",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.2",
+    "typedoc": "^0.26.11",
+    "typedoc-plugin-markdown": "^4.2.10",
     "typescript": "^5.4.5",
     "typescript-eslint": "^7.16.1"
   },
@@ -67,8 +69,9 @@
   },
   "scripts": {
     "set-version": "sed -i.bak -e \"s/\\${VERSION}/$(pulumictl get version --language javascript)/g\" package.json && rm package.json.bak",
-    "build": "tsc --build",
+    "build": "tsc --build && yarn docs && yarn format && yarn lint",
     "watch": "tsc --build --watch",
+    "docs": "npx typedoc",
     "lint": "./node_modules/.bin/eslint --ext .js,.jsx,.ts,.tsx --fix --no-error-on-unmatched-pattern src",
     "format": "./node_modules/.bin/prettier --write \"src/**/*.ts\" \"examples/**/*.ts\"",
     "test": "jest --passWithNoTests --updateSnapshot",

--- a/src/custom-resource-mapping.ts
+++ b/src/custom-resource-mapping.ts
@@ -31,25 +31,31 @@ export function mapToCustomResource(
     if (isCustomResource(typeName)) {
         const synth = stack.synthesizer;
         if (!(synth instanceof PulumiSynthesizerBase)) {
-            throw new Error(`Synthesizer of stack ${stack.node.id} does not support custom resources. It must inherit from ${PulumiSynthesizerBase.name}.`);
+            throw new Error(
+                `Synthesizer of stack ${stack.node.id} does not support custom resources. It must inherit from ${PulumiSynthesizerBase.name}.`,
+            );
         }
 
         const stagingBucket = synth.getStagingBucket();
         const stackId = stack.node.id;
 
-        return new aws.cloudformation.CustomResourceEmulator(logicalId, {
-            stackId: stack.node.id,
-            bucketName: stagingBucket,
-            bucketKeyPrefix: `${synth.getDeployTimePrefix()}pulumi/custom-resources/${stackId}/${logicalId}`,
-            serviceToken: rawProps.ServiceToken,
-            resourceType: typeName,
-            customResourceProperties: rawProps,
-        }, {
-            ...options,
-            customTimeouts: convertToCustomTimeouts(rawProps.ServiceTimeout),
-        });
+        return new aws.cloudformation.CustomResourceEmulator(
+            logicalId,
+            {
+                stackId: stack.node.id,
+                bucketName: stagingBucket,
+                bucketKeyPrefix: `${synth.getDeployTimePrefix()}pulumi/custom-resources/${stackId}/${logicalId}`,
+                serviceToken: rawProps.ServiceToken,
+                resourceType: typeName,
+                customResourceProperties: rawProps,
+            },
+            {
+                ...options,
+                customTimeouts: convertToCustomTimeouts(rawProps.ServiceTimeout),
+            },
+        );
     }
-    
+
     return undefined;
 }
 

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -54,8 +54,8 @@ export interface ConstructInfo {
 }
 
 export interface ConstructMetadata {
-    "fqn": string;
-    "version": string;
+    fqn: string;
+    version: string;
 }
 
 export interface GraphNode {
@@ -235,7 +235,7 @@ export class GraphBuilder {
         // CDK CustomResource are exposed as a CfnResource with the ID "Default"
         // If the parent construct has the fqn of CustomResource and the current tree node is the "Default" node
         // then we need to treat it as a Custom Resource
-        return parent?.constructInfo?.fqn === 'aws-cdk-lib.CustomResource' && node.id === 'Default'
+        return parent?.constructInfo?.fqn === 'aws-cdk-lib.CustomResource' && node.id === 'Default';
     }
 
     private _build(): Graph {
@@ -259,7 +259,9 @@ export class GraphBuilder {
         });
         if (unmappedResources.length > 0) {
             const total = Object.keys(this.stack.resources).length;
-            throw new Error(`${unmappedResources.length} out of ${total} CDK resources failed to map to Pulumi resources.`);
+            throw new Error(
+                `${unmappedResources.length} out of ${total} CDK resources failed to map to Pulumi resources.`,
+            );
         }
 
         // parseTree does not guarantee that the VPC resource will be parsed before the VPCCidrBlock resource

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,6 @@ export * from './output';
 
 import * as interop from './interop';
 export { interop };
-export { AppResourceOptions, AppOptions } from './types';
+export { AppResourceOptions, AppOptions, AppComponent, PulumiProvider } from './types';
 import * as synthesizer from './synthesizer';
 export { synthesizer };

--- a/src/interop.ts
+++ b/src/interop.ts
@@ -18,6 +18,9 @@ import { toSdkName } from './naming';
 import { PulumiProvider } from './types';
 import { PulumiResourceType } from './graph';
 
+/**
+ * @internal
+ */
 export function firstToLower(str: string) {
     return str.replace(/\w\S*/g, function (txt) {
         return txt.charAt(0).toLowerCase() + txt.substring(1);
@@ -39,11 +42,11 @@ export function normalize(value: any, cfnType?: string, pulumiProvider?: PulumiP
     if (!value) return value;
 
     if (value instanceof Promise) {
-        return pulumi.output(value).apply(v => normalize(v, cfnType, pulumiProvider));
+        return pulumi.output(value).apply((v) => normalize(v, cfnType, pulumiProvider));
     }
 
     if (pulumi.Output.isInstance(value)) {
-        return value.apply(v => normalize(v, cfnType, pulumiProvider));
+        return value.apply((v) => normalize(v, cfnType, pulumiProvider));
     }
 
     if (Array.isArray(value)) {
@@ -92,6 +95,9 @@ export type ResourceAttributeMappingArray = (ResourceAttributeMapping & { logica
 
 export type ResourceMapping = ResourceAttributeMapping | pulumi.Resource | ResourceAttributeMappingArray;
 
+/**
+ * @internal
+ */
 export class CdkConstruct extends pulumi.ComponentResource {
     constructor(public readonly name: PulumiResourceType, type?: string, options?: pulumi.ComponentResourceOptions) {
         const constructType = type ?? 'Construct';

--- a/src/pulumi-metadata.ts
+++ b/src/pulumi-metadata.ts
@@ -20,7 +20,6 @@ import { PulumiProvider } from './types';
 import { debug } from '@pulumi/pulumi/log';
 import * as pulumi from '@pulumi/pulumi';
 
-
 export class UnknownCfnType extends Error {
     constructor(cfnType: string) {
         super(`CfnType ${cfnType} doesn't exist as a native type`);
@@ -286,11 +285,11 @@ export function normalizeObject(key: string[], value: any, cfnType?: string, pul
     if (!value) return value;
 
     if (value instanceof Promise) {
-        return pulumi.output(value).apply(v => normalizeObject(key, v, cfnType, pulumiProvider));
+        return pulumi.output(value).apply((v) => normalizeObject(key, v, cfnType, pulumiProvider));
     }
 
     if (pulumi.Output.isInstance(value)) {
-        return value.apply(v => normalizeObject(key, v, cfnType, pulumiProvider));
+        return value.apply((v) => normalizeObject(key, v, cfnType, pulumiProvider));
     }
 
     if (Array.isArray(value)) {

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -179,6 +179,8 @@ export class App
      *
      * Note: currently lookups are disabled so this will only be executed once
      *
+     * @hidden
+     *
      * @param context The CDK context collected by the CLI that needs to be passed to the cdk.App
      * @returns the path to the CDK Assembly directory
      */

--- a/src/synthesizer.ts
+++ b/src/synthesizer.ts
@@ -108,7 +108,6 @@ export abstract class PulumiSynthesizerBase extends cdk.StackSynthesizer {
      */
     public abstract getStagingBucket(): pulumi.Input<string>;
 
-
     /**
      * Returns the S3 key prefix that will be used for deploy time assets.
      */
@@ -451,6 +450,8 @@ export class PulumiSynthesizer extends PulumiSynthesizerBase implements cdk.IReu
      * Also, we currently only support a single stack so we don't have to worry
      * about this being created multiple times. If we change the way this library
      * works and allow for multiple stacks we will have to revisit this
+     *
+     * @hidden
      */
     public reusableBind(stack: cdk.Stack): cdk.IBoundStackSynthesizer {
         // Create a copy of the current object and bind that
@@ -466,6 +467,8 @@ export class PulumiSynthesizer extends PulumiSynthesizerBase implements cdk.IReu
      *
      * NOTE: For our purposes we, we don't need to worry about calling this,
      * it will automatically get called by the underlying CDK stack construct
+     *
+     * @hidden
      */
     public bind(stack: cdk.Stack) {
         super.bind(stack);
@@ -483,6 +486,8 @@ export class PulumiSynthesizer extends PulumiSynthesizerBase implements cdk.IReu
      * Usually the default synthesizers will then take the data and add it to the asset manifest
      * for the stack. In our case we can just directly upload the files and then we don't have to
      * later post-process the assets from the manifest
+     *
+     * @hidden
      */
     public addFileAsset(asset: cdk.FileAssetSource): cdk.FileAssetLocation {
         assertBound(this.cdkAccount);
@@ -570,6 +575,8 @@ export class PulumiSynthesizer extends PulumiSynthesizerBase implements cdk.IReu
      * for the stack. In our case we can just directly push the images and then we don't have to
      * later post-process the assets from the manifest
      *
+     * @hidden
+     *
      * @param asset - The cdk asset to add
      * @returns The location of the asset. This will be the reference to the image ref
      */
@@ -651,6 +658,8 @@ export class PulumiSynthesizer extends PulumiSynthesizerBase implements cdk.IReu
 
     /**
      * We synthesize the template and the asset manifest
+     *
+     * @hidden
      */
     synthesize(session: cdk.ISynthesisSession): void {
         const templateAssetSource = this.synthesizeTemplate(session);
@@ -704,6 +713,8 @@ function fromCdkCacheFrom(cacheFrom?: cdk.DockerCacheOption[]): docker.types.inp
 /**
  * Converts the CDK NetworkMode to the Pulumi Docker.NetworkMode
  *
+ * @hidden
+ *
  * @param networkMode - The cdk network mode
  * @returns The docker network mode
  */
@@ -721,6 +732,8 @@ export function asNetworkMode(networkMode?: string): docker.NetworkMode | undefi
 
 /**
  * Converts the CDK Platform to the Pulumi Docker.Platform
+ *
+ * @hidden
  *
  * @param platform - The cdk platform
  * @returns The docker platform

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,20 @@
+{
+  "plugin": "typedoc-plugin-markdown",
+  "entryPoints": ["src/index.ts"],
+  "out": "api-docs",
+  "cleanOutputDir": true,
+  "outputFileStrategy": "modules",
+  "flattenOutputFiles": true,
+  "parametersFormat": "table",
+  "classPropertiesFormat": "table",
+  "enumMembersFormat": "table",
+  "typeDeclarationFormat": "table",
+  "propertyMembersFormat": "table",
+  "interfacePropertiesFormat": "table",
+  "excludeInternal": true,
+  "excludeProtected": true,
+  "excludeReferences": true,
+  "excludePrivate": true,
+  "excludeExternals": true,
+  "readme": "none"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1110,6 +1110,48 @@
   resolved "https://registry.yarnpkg.com/@pulumi/query/-/query-0.3.0.tgz#f496608e86a18c3dd31b6c533408e2441c29071d"
   integrity sha512-xfo+yLRM2zVjVEA4p23IjQWzyWl1ZhWOGobsBqRpIarzLvwNH/RAGaoehdxlhx4X92302DrpdIFgTICMN4P38w==
 
+"@shikijs/core@1.23.1":
+  version "1.23.1"
+  resolved "https://registry.yarnpkg.com/@shikijs/core/-/core-1.23.1.tgz#911473e672e4f2d15ca36b28b28179c0959aa7af"
+  integrity sha512-NuOVgwcHgVC6jBVH5V7iblziw6iQbWWHrj5IlZI3Fqu2yx9awH7OIQkXIcsHsUmY19ckwSgUMgrqExEyP5A0TA==
+  dependencies:
+    "@shikijs/engine-javascript" "1.23.1"
+    "@shikijs/engine-oniguruma" "1.23.1"
+    "@shikijs/types" "1.23.1"
+    "@shikijs/vscode-textmate" "^9.3.0"
+    "@types/hast" "^3.0.4"
+    hast-util-to-html "^9.0.3"
+
+"@shikijs/engine-javascript@1.23.1":
+  version "1.23.1"
+  resolved "https://registry.yarnpkg.com/@shikijs/engine-javascript/-/engine-javascript-1.23.1.tgz#0f634bea22cb14f471835b7b5f1da66bc34bd359"
+  integrity sha512-i/LdEwT5k3FVu07SiApRFwRcSJs5QM9+tod5vYCPig1Ywi8GR30zcujbxGQFJHwYD7A5BUqagi8o5KS+LEVgBg==
+  dependencies:
+    "@shikijs/types" "1.23.1"
+    "@shikijs/vscode-textmate" "^9.3.0"
+    oniguruma-to-es "0.4.1"
+
+"@shikijs/engine-oniguruma@1.23.1":
+  version "1.23.1"
+  resolved "https://registry.yarnpkg.com/@shikijs/engine-oniguruma/-/engine-oniguruma-1.23.1.tgz#c6c34c9152cf90c1ee75fcdbd124253c8ad0635f"
+  integrity sha512-KQ+lgeJJ5m2ISbUZudLR1qHeH3MnSs2mjFg7bnencgs5jDVPeJ2NVDJ3N5ZHbcTsOIh0qIueyAJnwg7lg7kwXQ==
+  dependencies:
+    "@shikijs/types" "1.23.1"
+    "@shikijs/vscode-textmate" "^9.3.0"
+
+"@shikijs/types@1.23.1":
+  version "1.23.1"
+  resolved "https://registry.yarnpkg.com/@shikijs/types/-/types-1.23.1.tgz#2386d49258be03e7b40fea1f28fda952739ad93d"
+  integrity sha512-98A5hGyEhzzAgQh2dAeHKrWW4HfCMeoFER2z16p5eJ+vmPeF6lZ/elEne6/UCU551F/WqkopqRsr1l2Yu6+A0g==
+  dependencies:
+    "@shikijs/vscode-textmate" "^9.3.0"
+    "@types/hast" "^3.0.4"
+
+"@shikijs/vscode-textmate@^9.3.0":
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/@shikijs/vscode-textmate/-/vscode-textmate-9.3.0.tgz#b2f1776e488c1d6c2b6cd129bab62f71bbc9c7ab"
+  integrity sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==
+
 "@sigstore/bundle@^2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@sigstore/bundle/-/bundle-2.3.2.tgz#ad4dbb95d665405fd4a7a02c8a073dbd01e4e95e"
@@ -1298,6 +1340,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/hast@^3.0.0", "@types/hast@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-3.0.4.tgz#1d6b39993b82cea6ad783945b0508c25903e15aa"
+  integrity sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==
+  dependencies:
+    "@types/unist" "*"
+
 "@types/http-cache-semantics@*":
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz#b979ebad3919799c979b17c72621c0bc0a31c6c4"
@@ -1343,6 +1392,13 @@
   integrity sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==
   dependencies:
     "@types/node" "*"
+
+"@types/mdast@^4.0.0":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-4.0.4.tgz#7ccf72edd2f1aa7dd3437e180c64373585804dd6"
+  integrity sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==
+  dependencies:
+    "@types/unist" "*"
 
 "@types/minimatch@^5.1.2":
   version "5.1.2"
@@ -1403,6 +1459,11 @@
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.6.tgz#d785ee90c52d7cc020e249c948c36f7b32d1e217"
   integrity sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==
+
+"@types/unist@*", "@types/unist@^3.0.0":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
+  integrity sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==
 
 "@types/yargs-parser@*":
   version "21.0.3"
@@ -1497,7 +1558,7 @@
     "@typescript-eslint/types" "7.18.0"
     eslint-visitor-keys "^3.4.3"
 
-"@ungap/structured-clone@^1.2.0":
+"@ungap/structured-clone@^1.0.0", "@ungap/structured-clone@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
@@ -2037,6 +2098,11 @@ case@1.6.3:
   resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
   integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
 
+ccount@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
+  integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
+
 cdk-assets@^2.154.8:
   version "2.155.16"
   resolved "https://registry.yarnpkg.com/cdk-assets/-/cdk-assets-2.155.16.tgz#dca1d76f926f5a63a62809a34d1cbb1f9a325e2e"
@@ -2071,6 +2137,16 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
+character-entities-html4@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-2.1.0.tgz#1f1adb940c971a4b22ba39ddca6b618dc6e56b2b"
+  integrity sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==
+
+character-entities-legacy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz#76bc83a90738901d7bc223a9e93759fdd560125b"
+  integrity sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==
 
 chownr@^2.0.0:
   version "2.0.0"
@@ -2155,6 +2231,11 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+comma-separated-tokens@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz#4e89c9458acb61bc8fef19f4529973b2392839ee"
+  integrity sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==
 
 common-ancestor-path@^1.0.1:
   version "1.0.1"
@@ -2307,10 +2388,22 @@ define-data-property@^1.1.4:
     es-errors "^1.3.0"
     gopd "^1.0.1"
 
+dequal@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
 detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
+devlop@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/devlop/-/devlop-1.1.0.tgz#4db7c2ca4dc6e0e834c30be70c94bbc976dc7018"
+  integrity sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==
+  dependencies:
+    dequal "^2.0.0"
 
 diff-sequences@^29.6.3:
   version "29.6.3"
@@ -2353,6 +2446,11 @@ emittery@^0.13.1:
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.13.1.tgz#c04b8c3457490e0847ae51fced3af52d338e3dad"
   integrity sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==
 
+emoji-regex-xs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz#e8af22e5d9dbd7f7f22d280af3d19d2aab5b0724"
+  integrity sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -2371,6 +2469,11 @@ end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+entities@^4.4.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 env-paths@^2.2.0:
   version "2.2.1"
@@ -2924,6 +3027,30 @@ hasown@^2.0.0, hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hast-util-to-html@^9.0.3:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/hast-util-to-html/-/hast-util-to-html-9.0.3.tgz#a9999a0ba6b4919576a9105129fead85d37f302b"
+  integrity sha512-M17uBDzMJ9RPCqLMO92gNNUDuBSq10a25SDBI08iCCxmorf4Yy6sYHK57n9WAbRAAaU+DuR4W6GN9K4DFZesYg==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    ccount "^2.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-whitespace "^3.0.0"
+    html-void-elements "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    property-information "^6.0.0"
+    space-separated-tokens "^2.0.0"
+    stringify-entities "^4.0.0"
+    zwitch "^2.0.4"
+
+hast-util-whitespace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz#7778ed9d3c92dd9e8c5c8f648a49c21fc51cb621"
+  integrity sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
 hosted-git-info@^7.0.0, hosted-git-info@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-7.0.2.tgz#9b751acac097757667f30114607ef7b661ff4f17"
@@ -2935,6 +3062,11 @@ html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+html-void-elements@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-3.0.0.tgz#fc9dbd84af9e747249034d4d62602def6517f1d7"
+  integrity sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
 
 http-cache-semantics@^4.0.0, http-cache-semantics@^4.1.1:
   version "4.1.1"
@@ -3743,6 +3875,13 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+linkify-it@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.0.tgz#9ef238bfa6dc70bd8e7f9572b52d369af569b421"
+  integrity sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==
+  dependencies:
+    uc.micro "^2.0.0"
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -3836,6 +3975,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lunr@^2.3.9:
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
+  integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
+
 make-dir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
@@ -3873,6 +4017,38 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
+markdown-it@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-14.1.0.tgz#3c3c5992883c633db4714ccb4d7b5935d98b7d45"
+  integrity sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==
+  dependencies:
+    argparse "^2.0.1"
+    entities "^4.4.0"
+    linkify-it "^5.0.0"
+    mdurl "^2.0.0"
+    punycode.js "^2.3.1"
+    uc.micro "^2.1.0"
+
+mdast-util-to-hast@^13.0.0:
+  version "13.2.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz#5ca58e5b921cc0a3ded1bc02eed79a4fe4fe41f4"
+  integrity sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    "@ungap/structured-clone" "^1.0.0"
+    devlop "^1.0.0"
+    micromark-util-sanitize-uri "^2.0.0"
+    trim-lines "^3.0.0"
+    unist-util-position "^5.0.0"
+    unist-util-visit "^5.0.0"
+    vfile "^6.0.0"
+
+mdurl@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-2.0.0.tgz#80676ec0433025dd3e17ee983d0fe8de5a2237e0"
+  integrity sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -3882,6 +4058,38 @@ merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+micromark-util-character@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-character/-/micromark-util-character-2.1.1.tgz#2f987831a40d4c510ac261e89852c4e9703ccda6"
+  integrity sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-encode@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz#0d51d1c095551cfaac368326963cf55f15f540b8"
+  integrity sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==
+
+micromark-util-sanitize-uri@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz#ab89789b818a58752b73d6b55238621b7faa8fd7"
+  integrity sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-encode "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-symbol@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz#e5da494e8eb2b071a0d08fb34f6cefec6c0a19b8"
+  integrity sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==
+
+micromark-util-types@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-types/-/micromark-util-types-2.0.1.tgz#a3edfda3022c6c6b55bfb049ef5b75d70af50709"
+  integrity sha512-534m2WhVTddrcKVepwmVEVnUAmtrx9bfIjNoQHRqfnvdaHQiFytEhJoTgpWJvDEXCO5gLTQh3wYC1PgOJA4NSQ==
 
 micromatch@^4.0.4:
   version "4.0.8"
@@ -3937,7 +4145,7 @@ minimatch@^5.0.1, minimatch@^5.1.0:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^9.0.0, minimatch@^9.0.4:
+minimatch@^9.0.0, minimatch@^9.0.4, minimatch@^9.0.5:
   version "9.0.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
   integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
@@ -4175,6 +4383,15 @@ onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+oniguruma-to-es@0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/oniguruma-to-es/-/oniguruma-to-es-0.4.1.tgz#112fbcd5fafe4f635983425a6db88f3e2de37107"
+  integrity sha512-rNcEohFz095QKGRovP/yqPIKc+nP+Sjs4YTHMv33nMePGKrq/r2eu9Yh4646M5XluGJsUnmwoXuiXE69KDs+fQ==
+  dependencies:
+    emoji-regex-xs "^1.0.0"
+    regex "^5.0.0"
+    regex-recursion "^4.2.1"
 
 optionator@^0.9.3:
   version "0.9.4"
@@ -4456,6 +4673,11 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
+property-information@^6.0.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.5.0.tgz#6212fbb52ba757e92ef4fb9d657563b933b7ffec"
+  integrity sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==
+
 protobufjs@^7.2.5:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.4.0.tgz#7efe324ce9b3b61c82aae5de810d287bc08a248a"
@@ -4481,6 +4703,11 @@ pump@^3.0.0:
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
+
+punycode.js@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode.js/-/punycode.js-2.3.1.tgz#6b53e56ad75588234e79f4affa90972c7dd8cdb7"
+  integrity sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==
 
 punycode@1.3.2:
   version "1.3.2"
@@ -4574,6 +4801,25 @@ readdir-glob@^1.1.2:
   integrity sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==
   dependencies:
     minimatch "^5.1.0"
+
+regex-recursion@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/regex-recursion/-/regex-recursion-4.2.1.tgz#024ee28593b8158e568307b99bf1b7a3d5ea31e9"
+  integrity sha512-QHNZyZAeKdndD1G3bKAbBEKOSSK4KOHQrAJ01N1LJeb0SoH4DJIeFhp0uUpETgONifS4+P3sOgoA1dhzgrQvhA==
+  dependencies:
+    regex-utilities "^2.3.0"
+
+regex-utilities@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/regex-utilities/-/regex-utilities-2.3.0.tgz#87163512a15dce2908cf079c8960d5158ff43280"
+  integrity sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==
+
+regex@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/regex/-/regex-5.0.2.tgz#291d960467e6499a79ceec022d20a4e0df67c54f"
+  integrity sha512-/pczGbKIQgfTMRV0XjABvc5RzLqQmwqxLHdQao2RTXPk+pmTXB2P0IaUHYdYyk412YLwUIkaeMd5T+RzVgTqnQ==
+  dependencies:
+    regex-utilities "^2.3.0"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -4725,6 +4971,18 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+shiki@^1.16.2:
+  version "1.23.1"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-1.23.1.tgz#02f149e8f2592509e701f3a806fd4f3dd64d17e9"
+  integrity sha512-8kxV9TH4pXgdKGxNOkrSMydn1Xf6It8lsle0fiqxf7a1149K1WGtdOu3Zb91T5r1JpvRPxqxU3C2XdZZXQnrig==
+  dependencies:
+    "@shikijs/core" "1.23.1"
+    "@shikijs/engine-javascript" "1.23.1"
+    "@shikijs/engine-oniguruma" "1.23.1"
+    "@shikijs/types" "1.23.1"
+    "@shikijs/vscode-textmate" "^9.3.0"
+    "@types/hast" "^3.0.4"
+
 shimmer@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
@@ -4813,6 +5071,11 @@ source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+space-separated-tokens@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz#1ecd9d2350a3844572c3f4a312bceb018348859f"
+  integrity sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==
 
 spdx-correct@^3.0.0:
   version "3.2.0"
@@ -4914,6 +5177,14 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
+
+stringify-entities@^4.0.0:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-4.0.4.tgz#b3b79ef5f277cc4ac73caeb0236c5ba939b3a4f3"
+  integrity sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==
+  dependencies:
+    character-entities-html4 "^2.0.0"
+    character-entities-legacy "^3.0.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
@@ -5068,6 +5339,11 @@ treeverse@^3.0.0:
   resolved "https://registry.yarnpkg.com/treeverse/-/treeverse-3.0.0.tgz#dd82de9eb602115c6ebd77a574aae67003cb48c8"
   integrity sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ==
 
+trim-lines@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
+  integrity sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==
+
 ts-api-utils@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.3.0.tgz#4b490e27129f1e8e686b45cc4ab63714dc60eea1"
@@ -5138,6 +5414,22 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
+typedoc-plugin-markdown@^4.2.10:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.2.10.tgz#cd386e9f2dec122cae79e487983811d92ac37161"
+  integrity sha512-PLX3pc1/7z13UJm4TDE9vo9jWGcClFUErXXtd5LdnoLjV6mynPpqZLU992DwMGFSRqJFZeKbVyqlNNeNHnk2tQ==
+
+typedoc@^0.26.11:
+  version "0.26.11"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.26.11.tgz#124b43a5637b7f3237b8c721691b44738c5c9dc9"
+  integrity sha512-sFEgRRtrcDl2FxVP58Ze++ZK2UQAEvtvvH8rRlig1Ja3o7dDaMHmaBfvJmdGnNEFaLTpQsN8dpvZaTqJSu/Ugw==
+  dependencies:
+    lunr "^2.3.9"
+    markdown-it "^14.1.0"
+    minimatch "^9.0.5"
+    shiki "^1.16.2"
+    yaml "^2.5.1"
+
 typescript-eslint@^7.16.1:
   version "7.18.0"
   resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-7.18.0.tgz#e90d57649b2ad37a7475875fa3e834a6d9f61eb2"
@@ -5151,6 +5443,11 @@ typescript@^5.4.5:
   version "5.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
   integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
+
+uc.micro@^2.0.0, uc.micro@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-2.1.0.tgz#f8d3f7d0ec4c3dea35a7e3c8efa4cb8b45c9e7ee"
+  integrity sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==
 
 undici-types@~6.19.2, undici-types@~6.19.8:
   version "6.19.8"
@@ -5170,6 +5467,44 @@ unique-slug@^4.0.0:
   integrity sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==
   dependencies:
     imurmurhash "^0.1.4"
+
+unist-util-is@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-6.0.0.tgz#b775956486aff107a9ded971d996c173374be424"
+  integrity sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
+unist-util-position@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-5.0.0.tgz#678f20ab5ca1207a97d7ea8a388373c9cf896be4"
+  integrity sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
+unist-util-stringify-position@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz#449c6e21a880e0855bf5aabadeb3a740314abac2"
+  integrity sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
+unist-util-visit-parents@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz#4d5f85755c3b8f0dc69e21eca5d6d82d22162815"
+  integrity sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
+
+unist-util-visit@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-5.0.0.tgz#a7de1f31f72ffd3519ea71814cccf5fd6a9217d6"
+  integrity sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
+    unist-util-visit-parents "^6.0.0"
 
 universalify@^2.0.0:
   version "2.0.1"
@@ -5256,6 +5591,22 @@ validate-npm-package-name@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz#a316573e9b49f3ccd90dbb6eb52b3f06c6d604e8"
   integrity sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==
+
+vfile-message@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-4.0.2.tgz#c883c9f677c72c166362fd635f21fc165a7d1181"
+  integrity sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-stringify-position "^4.0.0"
+
+vfile@^6.0.0:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-6.0.3.tgz#3652ab1c496531852bf55a6bac57af981ebc38ab"
+  integrity sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    vfile-message "^4.0.0"
 
 walk-up-path@^3.0.1:
   version "3.0.1"
@@ -5376,6 +5727,11 @@ yaml@1.10.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
+yaml@^2.5.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.6.1.tgz#42f2b1ba89203f374609572d5349fb8686500773"
+  integrity sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==
+
 yargs-parser@^20.2.2:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
@@ -5444,3 +5800,8 @@ zip-stream@^6.0.1:
     archiver-utils "^5.0.0"
     compress-commons "^6.0.2"
     readable-stream "^4.0.0"
+
+zwitch@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"
+  integrity sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==


### PR DESCRIPTION
This PR introduces a new tool [typedoc](https://typedoc.org/) which automatically generates API docs from TypeScript code. I think this is easier than having to remember to manually update the API documentation. It also forces us to add code comments to document the API.

I've also added a couple of scripts to the `build` script to ensure we run `docs`, `format`, && `lint` as part of `build`.