### PR TITLE
chore: add check worktree clean to build

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -22,6 +22,8 @@ runs:
     - name: Run build
       shell: bash
       run: yarn run build
+    - name: Check worktree clean
+      uses: pulumi/git-status-check-action@v1
     - name: Run unit tests
       shell: bash
       run: yarn run test

--- a/api-docs/Namespace.interop.md
+++ b/api-docs/Namespace.interop.md
@@ -21,8 +21,8 @@ attribute
 
 | Name | Type | Defined in |
 | ------ | ------ | ------ |
-| `attributes`? | `object` | [interop.ts:88](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/interop.ts#L88) |
-| `resource` | `pulumi.Resource` | [interop.ts:87](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/interop.ts#L87) |
+| `attributes`? | `object` | [interop.ts:88](https://github.com/pulumi/pulumi-cdk/blob/main/src/interop.ts#L88) |
+| `resource` | `pulumi.Resource` | [interop.ts:87](https://github.com/pulumi/pulumi-cdk/blob/main/src/interop.ts#L87) |
 
 #### Example
 
@@ -37,7 +37,7 @@ return {
 
 #### Defined in
 
-[interop.ts:86](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/interop.ts#L86)
+[interop.ts:86](https://github.com/pulumi/pulumi-cdk/blob/main/src/interop.ts#L86)
 
 ***
 
@@ -49,7 +49,7 @@ Use this type if a single CFN resource maps to multiple AWS resources
 
 #### Defined in
 
-[interop.ts:94](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/interop.ts#L94)
+[interop.ts:94](https://github.com/pulumi/pulumi-cdk/blob/main/src/interop.ts#L94)
 
 ***
 
@@ -59,7 +59,7 @@ Use this type if a single CFN resource maps to multiple AWS resources
 
 #### Defined in
 
-[interop.ts:96](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/interop.ts#L96)
+[interop.ts:96](https://github.com/pulumi/pulumi-cdk/blob/main/src/interop.ts#L96)
 
 ## Functions
 
@@ -86,4 +86,4 @@ The normalized resource properties
 
 #### Defined in
 
-[interop.ts:41](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/interop.ts#L41)
+[interop.ts:41](https://github.com/pulumi/pulumi-cdk/blob/main/src/interop.ts#L41)

--- a/api-docs/Namespace.synthesizer.md
+++ b/api-docs/Namespace.synthesizer.md
@@ -54,15 +54,15 @@ resources and deploy the assets themselves.
 
 ###### Defined in
 
-[synthesizer.ts:231](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L231)
+[synthesizer.ts:231](https://github.com/pulumi/pulumi-cdk/blob/main/src/synthesizer.ts#L231)
 
 #### Properties
 
 | Property | Modifier | Type | Default value | Description | Overrides | Defined in |
 | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| `stagingBucket?` | `public` | `BucketV2` | `undefined` | The app-scoped, environment-keyed staging bucket. | - | [synthesizer.ts:158](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L158) |
-| `stagingRepos` | `readonly` | `Record`\<`string`, `Repository`\> | `{}` | The app-scoped, environment-keyed ecr repositories associated with this app. | - | [synthesizer.ts:163](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L163) |
-| `stagingStack` | `readonly` | `CdkConstruct` | `undefined` | The Pulumi ComponentResource wrapper which contains all of the staging resources. This can be added to the `dependsOn` of the main stack to ensure the staging assets are created first | [`PulumiSynthesizerBase`](Namespace.synthesizer.md#pulumisynthesizerbase).`stagingStack` | [synthesizer.ts:153](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L153) |
+| `stagingBucket?` | `public` | `BucketV2` | `undefined` | The app-scoped, environment-keyed staging bucket. | - | [synthesizer.ts:158](https://github.com/pulumi/pulumi-cdk/blob/main/src/synthesizer.ts#L158) |
+| `stagingRepos` | `readonly` | `Record`\<`string`, `Repository`\> | `{}` | The app-scoped, environment-keyed ecr repositories associated with this app. | - | [synthesizer.ts:163](https://github.com/pulumi/pulumi-cdk/blob/main/src/synthesizer.ts#L163) |
+| `stagingStack` | `readonly` | `CdkConstruct` | `undefined` | The Pulumi ComponentResource wrapper which contains all of the staging resources. This can be added to the `dependsOn` of the main stack to ensure the staging assets are created first | [`PulumiSynthesizerBase`](Namespace.synthesizer.md#pulumisynthesizerbase).`stagingStack` | [synthesizer.ts:153](https://github.com/pulumi/pulumi-cdk/blob/main/src/synthesizer.ts#L153) |
 
 #### Methods
 
@@ -82,7 +82,7 @@ Returns the S3 key prefix that will be used for deploy time assets.
 
 ###### Defined in
 
-[synthesizer.ts:114](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L114)
+[synthesizer.ts:114](https://github.com/pulumi/pulumi-cdk/blob/main/src/synthesizer.ts#L114)
 
 ##### getStagingBucket()
 
@@ -101,7 +101,7 @@ and custom resource responses.
 
 ###### Defined in
 
-[synthesizer.ts:437](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L437)
+[synthesizer.ts:437](https://github.com/pulumi/pulumi-cdk/blob/main/src/synthesizer.ts#L437)
 
 ***
 
@@ -136,7 +136,7 @@ creates Pulumi resources then you should extend this class.
 
 | Property | Modifier | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ | ------ |
-| `stagingStack` | `abstract` | `CdkConstruct` | The Pulumi ComponentResource wrapper which contains all of the staging resources. This can be added to the `dependsOn` of the main stack to ensure the staging assets are created first | [synthesizer.ts:103](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L103) |
+| `stagingStack` | `abstract` | `CdkConstruct` | The Pulumi ComponentResource wrapper which contains all of the staging resources. This can be added to the `dependsOn` of the main stack to ensure the staging assets are created first | [synthesizer.ts:103](https://github.com/pulumi/pulumi-cdk/blob/main/src/synthesizer.ts#L103) |
 
 #### Methods
 
@@ -152,7 +152,7 @@ Returns the S3 key prefix that will be used for deploy time assets.
 
 ###### Defined in
 
-[synthesizer.ts:114](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L114)
+[synthesizer.ts:114](https://github.com/pulumi/pulumi-cdk/blob/main/src/synthesizer.ts#L114)
 
 ##### getStagingBucket()
 
@@ -167,7 +167,7 @@ and custom resource responses.
 
 ###### Defined in
 
-[synthesizer.ts:109](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L109)
+[synthesizer.ts:109](https://github.com/pulumi/pulumi-cdk/blob/main/src/synthesizer.ts#L109)
 
 ## Interfaces
 
@@ -177,10 +177,10 @@ and custom resource responses.
 
 | Property | Modifier | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ | ------ |
-| `appId` | `readonly` | `string` | A unique identifier for the application that the staging stack belongs to. This identifier will be used in the name of staging resources created for this application, and should be unique across CDK apps. The identifier should include lowercase characters, numbers, periods (.) and dashes ('-') only and have a maximum of 17 characters. | [synthesizer.ts:28](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L28) |
-| `autoDeleteStagingAssets?` | `readonly` | `boolean` | Auto deletes objects in the staging S3 bucket and images in the staging ECR repositories. This will also delete the S3 buckets and ECR repositories themselves when all objects / images are removed. **Default** `true` | [synthesizer.ts:73](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L73) |
-| `deployTimeFileAssetLifetime?` | `readonly` | `Duration` | The lifetime for deploy time file assets. Assets that are only necessary at deployment time (for instance, CloudFormation templates and Lambda source code bundles) will be automatically deleted after this many days. Assets that may be read from the staging bucket during your application's run time will not be deleted. Set this to the length of time you wish to be able to roll back to previous versions of your application without having to do a new `cdk synth` and re-upload of assets. **Default** `- Duration.days(30)` | [synthesizer.ts:52](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L52) |
-| `imageAssetVersionCount?` | `readonly` | `number` | The maximum number of image versions to store in a repository. Previous versions of an image can be stored for rollback purposes. Once a repository has more than 3 image versions stored, the oldest version will be discarded. This allows for sensible garbage collection while maintaining a few previous versions for rollback scenarios. **Default** `- up to 3 versions stored` | [synthesizer.ts:85](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L85) |
-| `parent?` | `readonly` | `Resource` | The parent resource for any Pulumi resources created by the Synthesizer | [synthesizer.ts:90](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L90) |
-| `stagingBucketName?` | `readonly` | `string` | Explicit name for the staging bucket **Default** `- a well-known name unique to this app/env.` | [synthesizer.ts:35](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L35) |
-| `stagingStackNamePrefix?` | `readonly` | `string` | Specify a custom prefix to be used as the staging stack name and construct ID. The prefix will be appended before the appId, which is required to be part of the stack name and construct ID to ensure uniqueness. **Default** `'staging-stack'` | [synthesizer.ts:62](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/synthesizer.ts#L62) |
+| `appId` | `readonly` | `string` | A unique identifier for the application that the staging stack belongs to. This identifier will be used in the name of staging resources created for this application, and should be unique across CDK apps. The identifier should include lowercase characters, numbers, periods (.) and dashes ('-') only and have a maximum of 17 characters. | [synthesizer.ts:28](https://github.com/pulumi/pulumi-cdk/blob/main/src/synthesizer.ts#L28) |
+| `autoDeleteStagingAssets?` | `readonly` | `boolean` | Auto deletes objects in the staging S3 bucket and images in the staging ECR repositories. This will also delete the S3 buckets and ECR repositories themselves when all objects / images are removed. **Default** `true` | [synthesizer.ts:73](https://github.com/pulumi/pulumi-cdk/blob/main/src/synthesizer.ts#L73) |
+| `deployTimeFileAssetLifetime?` | `readonly` | `Duration` | The lifetime for deploy time file assets. Assets that are only necessary at deployment time (for instance, CloudFormation templates and Lambda source code bundles) will be automatically deleted after this many days. Assets that may be read from the staging bucket during your application's run time will not be deleted. Set this to the length of time you wish to be able to roll back to previous versions of your application without having to do a new `cdk synth` and re-upload of assets. **Default** `- Duration.days(30)` | [synthesizer.ts:52](https://github.com/pulumi/pulumi-cdk/blob/main/src/synthesizer.ts#L52) |
+| `imageAssetVersionCount?` | `readonly` | `number` | The maximum number of image versions to store in a repository. Previous versions of an image can be stored for rollback purposes. Once a repository has more than 3 image versions stored, the oldest version will be discarded. This allows for sensible garbage collection while maintaining a few previous versions for rollback scenarios. **Default** `- up to 3 versions stored` | [synthesizer.ts:85](https://github.com/pulumi/pulumi-cdk/blob/main/src/synthesizer.ts#L85) |
+| `parent?` | `readonly` | `Resource` | The parent resource for any Pulumi resources created by the Synthesizer | [synthesizer.ts:90](https://github.com/pulumi/pulumi-cdk/blob/main/src/synthesizer.ts#L90) |
+| `stagingBucketName?` | `readonly` | `string` | Explicit name for the staging bucket **Default** `- a well-known name unique to this app/env.` | [synthesizer.ts:35](https://github.com/pulumi/pulumi-cdk/blob/main/src/synthesizer.ts#L35) |
+| `stagingStackNamePrefix?` | `readonly` | `string` | Specify a custom prefix to be used as the staging stack name and construct ID. The prefix will be appended before the appId, which is required to be part of the stack name and construct ID to ensure uniqueness. **Default** `'staging-stack'` | [synthesizer.ts:62](https://github.com/pulumi/pulumi-cdk/blob/main/src/synthesizer.ts#L62) |

--- a/api-docs/README.md
+++ b/api-docs/README.md
@@ -14,7 +14,7 @@ The Pulumi provider to read the schema from
 
 | Enumeration Member | Value | Defined in |
 | ------ | ------ | ------ |
-| `AWS_NATIVE` | `"aws-native"` | [types.ts:62](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/types.ts#L62) |
+| `AWS_NATIVE` | `"aws-native"` | [types.ts:62](https://github.com/pulumi/pulumi-cdk/blob/main/src/types.ts#L62) |
 
 ## Classes
 
@@ -74,14 +74,14 @@ export const bucket = app.outputs['bucket'];
 
 ###### Defined in
 
-[stack.ts:96](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/stack.ts#L96)
+[stack.ts:96](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L96)
 
 #### Properties
 
 | Property | Modifier | Type | Default value | Description | Defined in |
 | ------ | ------ | ------ | ------ | ------ | ------ |
-| `name` | `readonly` | `string` | `undefined` | The name of the component | [stack.ts:55](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/stack.ts#L55) |
-| `outputs` | `public` | `object` | `{}` | The collection of outputs from the AWS CDK Stack represented as Pulumi Outputs. Each CfnOutput defined in the AWS CDK Stack will populate a value in the outputs. | [stack.ts:61](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/stack.ts#L61) |
+| `name` | `readonly` | `string` | `undefined` | The name of the component | [stack.ts:55](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L55) |
+| `outputs` | `public` | `object` | `{}` | The collection of outputs from the AWS CDK Stack represented as Pulumi Outputs. Each CfnOutput defined in the AWS CDK Stack will populate a value in the outputs. | [stack.ts:61](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L61) |
 
 ***
 
@@ -121,7 +121,7 @@ Create and register an AWS CDK stack deployed with Pulumi.
 
 ###### Defined in
 
-[stack.ts:261](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/stack.ts#L261)
+[stack.ts:261](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L261)
 
 #### Methods
 
@@ -151,7 +151,7 @@ A Pulumi Output value.
 
 ###### Defined in
 
-[stack.ts:274](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/stack.ts#L274)
+[stack.ts:274](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L274)
 
 ## Interfaces
 
@@ -163,7 +163,7 @@ AppComponent is the interface representing the Pulumi CDK App Component Resource
 
 | Property | Modifier | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ | ------ |
-| `name` | `readonly` | `string` | The name of the component | [types.ts:72](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/types.ts#L72) |
+| `name` | `readonly` | `string` | The name of the component | [types.ts:72](https://github.com/pulumi/pulumi-cdk/blob/main/src/types.ts#L72) |
 
 ***
 
@@ -175,8 +175,8 @@ Options for creating a Pulumi CDK App Component
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| `appId?` | `string` | A unique identifier for the application that the asset staging stack belongs to. This identifier will be used in the name of staging resources created for this application, and should be unique across apps. The identifier should include lowercase characters, numbers, periods (.) and dashes ('-') only and have a maximum of 17 characters. **Default** `- generated from the pulumi project and stack name` | [types.ts:25](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/types.ts#L25) |
-| `props?` | `AppProps` | Specify the CDK Stack properties to asociate with the stack. | [types.ts:12](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/types.ts#L12) |
+| `appId?` | `string` | A unique identifier for the application that the asset staging stack belongs to. This identifier will be used in the name of staging resources created for this application, and should be unique across apps. The identifier should include lowercase characters, numbers, periods (.) and dashes ('-') only and have a maximum of 17 characters. **Default** `- generated from the pulumi project and stack name` | [types.ts:25](https://github.com/pulumi/pulumi-cdk/blob/main/src/types.ts#L25) |
+| `props?` | `AppProps` | Specify the CDK Stack properties to asociate with the stack. | [types.ts:12](https://github.com/pulumi/pulumi-cdk/blob/main/src/types.ts#L12) |
 
 #### Methods
 
@@ -209,7 +209,7 @@ implemented.
 
 ###### Defined in
 
-[types.ts:42](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/types.ts#L42)
+[types.ts:42](https://github.com/pulumi/pulumi-cdk/blob/main/src/types.ts#L42)
 
 ***
 
@@ -225,7 +225,7 @@ Options specific to the Pulumi CDK App component.
 
 | Property | Type | Defined in |
 | ------ | ------ | ------ |
-| `appOptions?` | [`AppOptions`](README.md#appoptions) | [types.ts:54](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/types.ts#L54) |
+| `appOptions?` | [`AppOptions`](README.md#appoptions) | [types.ts:54](https://github.com/pulumi/pulumi-cdk/blob/main/src/types.ts#L54) |
 
 ***
 
@@ -241,7 +241,7 @@ Options for creating a Pulumi CDK Stack
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| `props?` | `StackProps` | The CDK Stack props | [stack.ts:227](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/stack.ts#L227) |
+| `props?` | `StackProps` | The CDK Stack props | [stack.ts:227](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L227) |
 
 ## Type Aliases
 
@@ -255,7 +255,7 @@ Options for creating a Pulumi CDK Stack
 
 #### Defined in
 
-[stack.ts:24](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/stack.ts#L24)
+[stack.ts:24](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L24)
 
 ## Functions
 
@@ -279,7 +279,7 @@ A CDK token representing a list of string values.
 
 #### Defined in
 
-[output.ts:45](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/output.ts#L45)
+[output.ts:45](https://github.com/pulumi/pulumi-cdk/blob/main/src/output.ts#L45)
 
 ***
 
@@ -303,7 +303,7 @@ A CDK token representing a number value.
 
 #### Defined in
 
-[output.ts:35](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/output.ts#L35)
+[output.ts:35](https://github.com/pulumi/pulumi-cdk/blob/main/src/output.ts#L35)
 
 ***
 
@@ -327,7 +327,7 @@ A CDK token representing a string value.
 
 #### Defined in
 
-[output.ts:25](https://github.com/pulumi/pulumi-cdk/blob/890dc36200787bf0cc83014ee6ebc4bc46e0db99/src/output.ts#L25)
+[output.ts:25](https://github.com/pulumi/pulumi-cdk/blob/main/src/output.ts#L25)
 
 ## Namespaces
 

--- a/src/converters/app-converter.ts
+++ b/src/converters/app-converter.ts
@@ -24,7 +24,7 @@ import { parseSub } from '../sub';
 import { getPartition } from '@pulumi/aws-native/getPartition';
 import { mapToCustomResource } from '../custom-resource-mapping';
 import { processSecretsManagerReferenceValue } from './secrets-manager-dynamic';
-import * as intrinsics from "./intrinsics";
+import * as intrinsics from './intrinsics';
 
 /**
  * AppConverter will convert all CDK resources into Pulumi resources.
@@ -647,8 +647,8 @@ export class StackConverter extends ArtifactConverter implements intrinsics.Intr
         return d.value;
     }
 
-    findCondition(conditionName: string): intrinsics.Expression|undefined {
-        if (conditionName in (this.stack.conditions||{})) {
+    findCondition(conditionName: string): intrinsics.Expression | undefined {
+        if (conditionName in (this.stack.conditions || {})) {
             return this.stack.conditions![conditionName];
         } else {
             return undefined;
@@ -667,7 +667,7 @@ export class StackConverter extends ArtifactConverter implements intrinsics.Intr
         return <any>r;
     }
 
-    apply<T,U>(result: intrinsics.Result<T>, fn: (value: U) => intrinsics.Result<U>): intrinsics.Result<U> {
+    apply<T, U>(result: intrinsics.Result<T>, fn: (value: U) => intrinsics.Result<U>): intrinsics.Result<U> {
         return lift(fn, result);
     }
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -16,5 +16,6 @@
   "excludeReferences": true,
   "excludePrivate": true,
   "excludeExternals": true,
+  "gitRevision": "main", 
   "readme": "none"
 }


### PR DESCRIPTION
Now that we run `docs`, `format`, & `lint` we should also ensure that we fail the build if there are any changes.