### PR TITLE
Improve the Ref intrinsic implementation

### DIFF
--- a/src/cfn.ts
+++ b/src/cfn.ts
@@ -14,8 +14,17 @@
 
 import { CfnDeletionPolicy } from 'aws-cdk-lib/core';
 
+/**
+ * Represents a CF parameter declaration from the Parameters template section.
+ *
+ * See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html
+ */
 export interface CloudFormationParameter {
+    /**
+     * DataType such as 'String'.
+     */
     readonly Type: string;
+
     readonly Default?: any;
 }
 

--- a/src/cfn.ts
+++ b/src/cfn.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { CloudFormationCreateReplaceChangeSetAction } from 'aws-cdk-lib/aws-codepipeline-actions';
 import { CfnDeletionPolicy } from 'aws-cdk-lib/core';
 
 /**
@@ -26,6 +27,12 @@ export interface CloudFormationParameter {
     readonly Type: string;
 
     readonly Default?: any;
+}
+
+export type CloudFormationParameterLogicalId = string;
+
+export interface CloudFormationParameterWithId extends CloudFormationParameter {
+    id: CloudFormationParameterLogicalId;
 }
 
 export interface CloudFormationResource {

--- a/src/cfn.ts
+++ b/src/cfn.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { CloudFormationCreateReplaceChangeSetAction } from 'aws-cdk-lib/aws-codepipeline-actions';
 import { CfnDeletionPolicy } from 'aws-cdk-lib/core';
 
 /**

--- a/src/converters/app-converter.ts
+++ b/src/converters/app-converter.ts
@@ -38,7 +38,6 @@ import { PulumiProvider } from '../types';
  * AppConverter will convert all CDK resources into Pulumi resources.
  */
 export class AppConverter {
-
     // Map of stack artifactId to StackConverter
     public readonly stacks = new Map<string, StackConverter>();
 

--- a/src/converters/app-converter.ts
+++ b/src/converters/app-converter.ts
@@ -643,7 +643,6 @@ export class StackConverter extends ArtifactConverter implements intrinsics.Intr
     }
 
     evaluateParameter(param: CloudFormationParameterWithId): intrinsics.Result<any> {
-        const paramName = param.id;
         const value = this.parameters.get(param.id);
         if (value === undefined) {
             throw new Error(`No value for the CloudFormation "${param.id}" parameter`);

--- a/src/converters/app-converter.ts
+++ b/src/converters/app-converter.ts
@@ -426,8 +426,15 @@ export class StackConverter extends ArtifactConverter implements intrinsics.Intr
         return obj?.Ref === 'AWS::NoValue';
     }
 
-    private resolveOutput(repr: OutputRepr): pulumi.Output<any> {
-        return OutputMap.instance().lookupOutput(repr)!;
+    /**
+     * @internal
+     */
+    public resolveOutput(repr: OutputRepr): pulumi.Output<any> {
+        const result = OutputMap.instance().lookupOutput(repr);
+        if (result === undefined) {
+            throw new Error(`@pulumi/pulumi-cdk internal failure: unable to resolveOutput ${repr.PulumiOutput}`);
+        }
+        return result;
     }
 
     private resolveIntrinsic(fn: string, params: any) {

--- a/src/converters/app-converter.ts
+++ b/src/converters/app-converter.ts
@@ -25,14 +25,9 @@ import { getPartition } from '@pulumi/aws-native/getPartition';
 import { mapToCustomResource } from '../custom-resource-mapping';
 import { processSecretsManagerReferenceValue } from './secrets-manager-dynamic';
 import * as intrinsics from './intrinsics';
-import {
-    CloudFormationParameter,
-    CloudFormationParameterLogicalId,
-    CloudFormationParameterWithId,
-} from '../cfn';
+import { CloudFormationParameter, CloudFormationParameterLogicalId, CloudFormationParameterWithId } from '../cfn';
 import { Metadata, PulumiResource } from '../pulumi-metadata';
 import { PulumiProvider } from '../types';
-
 
 /**
  * AppConverter will convert all CDK resources into Pulumi resources.
@@ -643,10 +638,8 @@ export class StackConverter extends ArtifactConverter implements intrinsics.Intr
     }
 
     findParameter(parameterLogicalID: CloudFormationParameterLogicalId): CloudFormationParameterWithId | undefined {
-        const p: CloudFormationParameter|undefined = (this.stack.parameters||{})[parameterLogicalID];
-        return p
-            ? {...p, id: "!!"}
-            : undefined;
+        const p: CloudFormationParameter | undefined = (this.stack.parameters || {})[parameterLogicalID];
+        return p ? { ...p, id: '!!' } : undefined;
     }
 
     evaluateParameter(param: CloudFormationParameterWithId): intrinsics.Result<any> {
@@ -661,7 +654,7 @@ export class StackConverter extends ArtifactConverter implements intrinsics.Intr
         return this.resources.get(resourceLogicalID);
     }
 
-    tryFindResource(cfnType: string): PulumiResource|undefined {
+    tryFindResource(cfnType: string): PulumiResource | undefined {
         const m = new Metadata(PulumiProvider.AWS_NATIVE);
         return m.tryFindResource(cfnType);
     }

--- a/src/converters/app-converter.ts
+++ b/src/converters/app-converter.ts
@@ -25,6 +25,8 @@ import { getPartition } from '@pulumi/aws-native/getPartition';
 import { mapToCustomResource } from '../custom-resource-mapping';
 import { processSecretsManagerReferenceValue } from './secrets-manager-dynamic';
 import * as intrinsics from './intrinsics';
+import { CloudFormationParameter } from '../cfn';
+
 
 /**
  * AppConverter will convert all CDK resources into Pulumi resources.
@@ -665,5 +667,24 @@ export class StackConverter extends ArtifactConverter implements intrinsics.Intr
 
     apply<T, U>(result: intrinsics.Result<T>, fn: (value: U) => intrinsics.Result<U>): intrinsics.Result<U> {
         return lift(fn, result);
+    }
+
+    findParameter(parameterLogicalID: string): CloudFormationParameter | undefined {
+        throw new Error("TODO");
+    }
+
+    findResourceMapping(resourceLogicalID: string): Mapping<pulumi.Resource> | undefined {
+        throw new Error("TODO");
+    }
+
+    evaluateParameter(param: CloudFormationParameter): intrinsics.Result<any> {
+        throw new Error("TODO");
+    }
+
+    /**
+     * Pulumi metadata source that may inform the intrinsic evaluation.
+     */
+    tryFindResource(cfnType: string): any {
+        throw new Error("TODO");
     }
 }

--- a/src/converters/app-converter.ts
+++ b/src/converters/app-converter.ts
@@ -637,15 +637,16 @@ export class StackConverter extends ArtifactConverter implements intrinsics.Intr
         return lift(fn, result);
     }
 
-    findParameter(parameterLogicalID: CloudFormationParameterLogicalId): CloudFormationParameterWithId | undefined {
-        const p: CloudFormationParameter | undefined = (this.stack.parameters || {})[parameterLogicalID];
-        return p ? { ...p, id: '!!' } : undefined;
+    findParameter(parameterLogicalId: CloudFormationParameterLogicalId): CloudFormationParameterWithId | undefined {
+        const p: CloudFormationParameter | undefined = (this.stack.parameters || {})[parameterLogicalId];
+        return p ? { ...p, id: parameterLogicalId } : undefined;
     }
 
     evaluateParameter(param: CloudFormationParameterWithId): intrinsics.Result<any> {
+        const paramName = param.id;
         const value = this.parameters.get(param.id);
-        if (value !== undefined) {
-            throw new Error(`No value for the CloudFormation ${param} parameter`);
+        if (value === undefined) {
+            throw new Error(`No value for the CloudFormation "${param.id}" parameter`);
         }
         return value;
     }

--- a/src/converters/intrinsics.ts
+++ b/src/converters/intrinsics.ts
@@ -366,7 +366,7 @@ function evaluateRef(ctx: IntrinsicContext, param: string): Result<any> {
         case 'AWS::URLSuffix':
             return ctx.getURLSuffix();
         case 'AWS::NotificationARNs':
-            return ctx.fail('AWS::NotificationARNs pseudo-parameter is not yet supported in pulumi-cdk')
+            return ctx.fail('AWS::NotificationARNs pseudo-parameter is not yet supported in pulumi-cdk');
         case 'AWS::StackId':
         case 'AWS::StackName': {
             // TODO[pulumi/pulumi-cdk#246]: these pseudo-parameters are typically used in things like names or descriptions

--- a/src/converters/intrinsics.ts
+++ b/src/converters/intrinsics.ts
@@ -299,7 +299,8 @@ export const ref: Intrinsic = {
         //
         // CF docs: "When the AWS::LanguageExtensions transform is used, you can use intrinsic functions..".
         if (typeof param !== 'string') {
-            return ctx.apply(mustBeString(ctx, ctx.evaluate(param)), name => evaluateRef(ctx, name));
+            const s = ctx.apply(ctx.evaluate(param), p => mustBeString(ctx, p));
+            return ctx.apply(s, name => evaluateRef(ctx, name));
         }
         return evaluateRef(ctx, param);
     },

--- a/src/converters/intrinsics.ts
+++ b/src/converters/intrinsics.ts
@@ -132,7 +132,7 @@ export interface IntrinsicContext {
     /**
      * Pulumi metadata source that may inform the intrinsic evaluation.
      */
-    tryFindResource(cfnType: string): PulumiResource|undefined;
+    tryFindResource(cfnType: string): PulumiResource | undefined;
 
     /**
      * Gets the CDK Stack Node ID.
@@ -333,18 +333,20 @@ export const ref: Intrinsic = {
 
         // Although not part of the CF spec, Output values are passed through CDK tokens as Ref structures; therefore
         // Pulumi Ref intrinsic receives them and has to handle them.
-        if (isOutputReprInstance(param)) { return ctx.resolveOutput(<OutputRepr>param); }
+        if (isOutputReprInstance(param)) {
+            return ctx.resolveOutput(<OutputRepr>param);
+        }
 
         // Unless the parameter is a literal string, it may be another expression.
         //
         // CF docs: "When the AWS::LanguageExtensions transform is used, you can use intrinsic functions..".
         if (typeof param !== 'string') {
-            const s = ctx.apply(ctx.evaluate(param), p => mustBeString(ctx, p));
-            return ctx.apply(s, name => evaluateRef(ctx, name));
+            const s = ctx.apply(ctx.evaluate(param), (p) => mustBeString(ctx, p));
+            return ctx.apply(s, (name) => evaluateRef(ctx, name));
         }
         return evaluateRef(ctx, param);
     },
-}
+};
 
 /**
  * See `ref`.
@@ -406,25 +408,25 @@ function evaluateRef(ctx: IntrinsicContext, param: string): Result<any> {
         }
 
         // At this point metadata should indicate which properties to extract from the resource to compute the ref.
-        const propNames: string[] = (resMeta.cfRef.properties||[])
-            .concat(resMeta.cfRef.property ? [resMeta.cfRef.property]: [])
-            .map(x => toSdkName(x));
+        const propNames: string[] = (resMeta.cfRef.properties || [])
+            .concat(resMeta.cfRef.property ? [resMeta.cfRef.property] : [])
+            .map((x) => toSdkName(x));
 
         const propValues: any[] = [];
         for (const p of propNames) {
             if (!Object.prototype.hasOwnProperty.call(map.resource, p)) {
-                return ctx.fail(`Pulumi metadata notes a property "${p}" but no such property was found on a resource`)
+                return ctx.fail(`Pulumi metadata notes a property "${p}" but no such property was found on a resource`);
             }
             propValues.push((<any>map.resource)[p]);
         }
 
-        const delim: string = resMeta.cfRef!.delimiter || "|";
+        const delim: string = resMeta.cfRef!.delimiter || '|';
 
-        return ctx.apply(ctx.succeed(propValues), resolvedValues => {
+        return ctx.apply(ctx.succeed(propValues), (resolvedValues) => {
             let i = 0;
             for (const v of resolvedValues) {
-                if (typeof v !== "string") {
-                    return ctx.fail(`Expected property "${propNames[i]}" to resolve to a string, got ${typeof(v)}`);
+                if (typeof v !== 'string') {
+                    return ctx.fail(`Expected property "${propNames[i]}" to resolve to a string, got ${typeof v}`);
                 }
                 i++;
             }
@@ -434,7 +436,6 @@ function evaluateRef(ctx: IntrinsicContext, param: string): Result<any> {
 
     return ctx.fail(`Ref intrinsic unable to resolve ${param}: not a known logical resource or parameter reference`);
 }
-
 
 /**
  * Recognize forms such as {"Condition" : "SomeOtherCondition"}. If recognized, returns the conditionName.

--- a/src/converters/intrinsics.ts
+++ b/src/converters/intrinsics.ts
@@ -365,12 +365,13 @@ function evaluateRef(ctx: IntrinsicContext, param: string): Result<any> {
             return ctx.getURLSuffix();
         case 'AWS::NotificationARNs':
         case 'AWS::StackId':
-        case 'AWS::StackName':
+        case 'AWS::StackName': {
             // TODO[pulumi/pulumi-cdk#246]: these pseudo-parameters are typically used in things like names or descriptions
             // so it should be safe to substitute with a stack node ID for most applications.
             const stackNodeId = ctx.getStackNodeId();
             debug(`pulumi-cdk is replacing a Ref to a CF pseudo-parameter ${param} with the stack node ID`);
             return stackNodeId;
+        }
     }
 
     // Handle Cf template parameters.

--- a/src/converters/intrinsics.ts
+++ b/src/converters/intrinsics.ts
@@ -386,7 +386,7 @@ function evaluateRef(ctx: IntrinsicContext, param: string): Result<any> {
     const map = ctx.findResourceMapping(param);
     if (map !== undefined) {
         if (map.attributes && 'id' in map.attributes) {
-            // Users my override the `id` in a custom-supplied mapping, respect this.
+            // Users may override the `id` in a custom-supplied mapping, respect this.
             return ctx.succeed(map.attributes.id);
         }
         if (aws.cloudformation.CustomResourceEmulator.isInstance(map.resource)) {

--- a/src/converters/intrinsics.ts
+++ b/src/converters/intrinsics.ts
@@ -366,6 +366,7 @@ function evaluateRef(ctx: IntrinsicContext, param: string): Result<any> {
         case 'AWS::URLSuffix':
             return ctx.getURLSuffix();
         case 'AWS::NotificationARNs':
+            return ctx.fail('AWS::NotificationARNs pseudo-parameter is not yet supported in pulumi-cdk')
         case 'AWS::StackId':
         case 'AWS::StackName': {
             // TODO[pulumi/pulumi-cdk#246]: these pseudo-parameters are typically used in things like names or descriptions

--- a/src/pulumi-metadata.ts
+++ b/src/pulumi-metadata.ts
@@ -45,11 +45,22 @@ export class Metadata {
      * @throws UnknownCfnType if the resource is not found
      */
     public findResource(cfnType: string): PulumiResource {
+        const r = this.tryFindResource(cfnType);
+        if (r === undefined) {
+            throw new UnknownCfnType(cfnType);
+        }
+        return r;
+    }
+
+    /**
+     * Non-throwing version of `findResource`.
+     */
+    public tryFindResource(cfnType: string): PulumiResource|undefined {
         const pType = typeToken(cfnType);
         if (pType in this.pulumiMetadata.resources) {
             return this.pulumiMetadata.resources[pType];
         }
-        throw new UnknownCfnType(cfnType);
+        return undefined;
     }
 
     public types(): { [key: string]: PulumiType } {
@@ -120,9 +131,49 @@ export interface PulumiProperty extends PulumiPropertyItems {
     items?: PulumiPropertyItems;
 }
 
+/**
+ * The schema for an individual resource.
+ */
 export interface PulumiResource {
+    cfRef?: CfRefBehavior;
     inputs: { [key: string]: PulumiProperty };
     outputs: { [key: string]: PulumiProperty };
+}
+
+/**
+ * Metadata predicting the behavior of CF Ref intrinsic for a given resource.
+ *
+ * @internal
+ */
+export interface CfRefBehavior {
+    /**
+     * If set, indicates that Ref will return the value of the given Resource property directly.
+     *
+     * The property name is a CF name such as "GroupId".
+     */
+    property?: string;
+
+    /**
+     * If set, indicates that Ref will return a string value obtained by joining several Resource properties with a
+     * delimiter, typically "|".
+     */
+    properties?: string[];
+
+    /**
+     * Delimiter for `properties`, typically "|".
+     */
+    delimiter?: string;
+
+    /**
+     * If set, Ref is not supported for this resource in CF.
+     */
+    notSupported?: boolean;
+
+    /**
+     * If set, Ref is supported in CF but this metadata is not yet available in the Pulumi aws-native provider but might
+     * be added in a later version.
+     */
+    notSupportedYet?: boolean;
 }
 
 /**

--- a/src/pulumi-metadata.ts
+++ b/src/pulumi-metadata.ts
@@ -55,7 +55,7 @@ export class Metadata {
     /**
      * Non-throwing version of `findResource`.
      */
-    public tryFindResource(cfnType: string): PulumiResource|undefined {
+    public tryFindResource(cfnType: string): PulumiResource | undefined {
         const pType = typeToken(cfnType);
         if (pType in this.pulumiMetadata.resources) {
             return this.pulumiMetadata.resources[pType];

--- a/tests/converters/intrinsics.test.ts
+++ b/tests/converters/intrinsics.test.ts
@@ -320,8 +320,10 @@ describe('Ref', () => {
         expect(runIntrinsic(intrinsics.ref, tc, ['AWS::URLSuffix'])).toEqual(ok('amazonaws.com.cn'));
         expect(runIntrinsic(intrinsics.ref, tc, ['AWS::NoValue'])).toEqual(ok(undefined));
 
+        expect(runIntrinsic(intrinsics.ref, tc, ['AWS::NotificationARNs']))
+            .toEqual(failed('AWS::NotificationARNs pseudo-parameter is not yet supported in pulumi-cdk'));
+
         // These are approximations; testing the current behavior for completeness sake.
-        expect(runIntrinsic(intrinsics.ref, tc, ['AWS::NotificationARNs'])).toEqual(ok(stackNodeId));
         expect(runIntrinsic(intrinsics.ref, tc, ['AWS::StackId'])).toEqual(ok(stackNodeId));
         expect(runIntrinsic(intrinsics.ref, tc, ['AWS::StackName'])).toEqual(ok(stackNodeId));
     });

--- a/tests/converters/intrinsics.test.ts
+++ b/tests/converters/intrinsics.test.ts
@@ -1,4 +1,10 @@
+import * as aws from '@pulumi/aws-native';
+import * as pulumi from '@pulumi/pulumi';
 import * as intrinsics from '../../src/converters/intrinsics';
+import { CloudFormationParameter } from '../../src/cfn';
+import { Mapping } from '../../src/types';
+import { PulumiResource } from '../../src/pulumi-metadata';
+
 
 describe('Fn::If', () => {
     test('picks true', async () => {
@@ -167,6 +173,127 @@ describe('Fn::Equals', () => {
     });
 })
 
+describe('Ref', () => {
+
+    // resolves AWS::AccountID
+    // resolves AWS:NotificationARNs
+    // resolves AWS::NoValue
+    // resolves AWS::Partition
+    // resolves AWS::Region
+    // resolves AWS::StackId
+    // resolves AWS::StackName
+    // resolves AWS::URLSuffix
+
+    test('resolves a parameter by its logical ID', async () => {
+        const tc = new TestContext({parameters: {
+            'MyParam': {Type: 'String', Default: 'MyParamValue'}
+        }});
+        const result = runIntrinsic(intrinsics.ref, tc, ['MyParam']);
+        expect(result).toEqual(ok('MyParamValue'));
+    });
+
+    test('respects "id" resource mapping provided by the user', async () => {
+        const tc = new TestContext({resources: {
+            'MyRes': {
+                resource: <any>{},
+                resourceType: 'AWS::S3::Bucket',
+                attributes: {
+                    'id': 'myID'
+                },
+            },
+        }});
+        const result = runIntrinsic(intrinsics.ref, tc, ['MyRes']);
+        expect(result).toEqual(ok('myID'));
+    });
+
+    test('resolves a CustomResource to its physical ID', async () => {
+        const tc = new TestContext({resources: {
+            'MyRes': {
+                resource: <any>{
+                    __pulumiType: (<any>aws.cloudformation.CustomResourceEmulator).__pulumiType,
+                    physicalResourceId: 'physicalID',
+                },
+                resourceType: 'AWS::CloudFormation::CustomResource',
+            },
+        }});
+        const result = runIntrinsic(intrinsics.ref, tc, ['MyRes']);
+        expect(result).toEqual(ok('physicalID'));
+    });
+
+    test('fails if Pulumi metadata indicates Ref is not supported', async () => {
+        const tc = new TestContext({
+            resources: {
+                'MyRes': {
+                    resource: <any>{},
+                    resourceType: 'AWS::S3::Bucket',
+                },
+            },
+            pulumiMetadata: {
+                'AWS::S3::Bucket': {
+                    inputs: {},
+                    outputs: {},
+                    cfRef: {
+                        notSupported: true,
+                    }
+                },
+            }
+        });
+        const result = runIntrinsic(intrinsics.ref, tc, ['MyRes']);
+        expect(result).toEqual(failed('Ref intrinsic is not supported for the AWS::S3::Bucket resource type'));
+    });
+
+    test('resolves to a property value indicated by Pulumi metadata', async () => {
+        const tc = new TestContext({
+            resources: {
+                'MyRes': {
+                    resource: <any>{stageName: 'my-stage'},
+                    resourceType: 'AWS::ApiGateway::Stage',
+                },
+            },
+            pulumiMetadata: {
+                'AWS::ApiGateway::Stage': {
+                    inputs: {},
+                    outputs: {},
+                    cfRef: {
+                        property: 'StageName',
+                    }
+                },
+            }
+        });
+        const result = runIntrinsic(intrinsics.ref, tc, ['MyRes']);
+        expect(result).toEqual(ok('my-stage'));
+    });
+
+    test('resolves to a join of several property values indicated by Pulumi metadata', async () => {
+        const tc = new TestContext({
+            resources: {
+                'MyRes': {
+                    resource: <any>{roleName: 'my-role', policyName: 'my-policy'},
+                    resourceType: 'AWS::IAM::RolePolicy',
+                },
+            },
+            pulumiMetadata: {
+                'AWS::IAM::RolePolicy': {
+                    inputs: {},
+                    outputs: {},
+                    cfRef: {
+                        properties: ['PolicyName', 'RoleName'],
+                        delimiter: '|',
+                    }
+                },
+            }
+        });
+        const result = runIntrinsic(intrinsics.ref, tc, ['MyRes']);
+        expect(result).toEqual(ok('my-policy|my-role'));
+    });
+
+    test('fails if called with an ID that does not resolve', async () => {
+        const tc = new TestContext({});
+        const result = runIntrinsic(intrinsics.ref, tc, ['MyParam']);
+        expect(result).toEqual(failed('Ref intrinsic unable to resolve MyParam: not a known logical resource or parameter reference'));
+    });
+})
+
 function runIntrinsic(fn: intrinsics.Intrinsic, tc: TestContext, args: intrinsics.Expression[]): TestResult<any> {
     const result: TestResult<any> = <any>(fn.evaluate(tc, args));
     return result;
@@ -186,18 +313,48 @@ function failed<T>(errorMessage: string): TestResult<T> {
 
 class TestContext implements intrinsics.IntrinsicContext {
     conditions: { [id: string]: intrinsics.Expression };
+    parameters: { [id: string]: CloudFormationParameter };
+    resources: { [id: string]: Mapping<pulumi.Resource> };
+    pulumiMetadata: { [cfnType: string]: PulumiResource };
 
-    constructor(args: {conditions?: { [id: string]: intrinsics.Expression }}) {
-        if (args.conditions) {
-            this.conditions = args.conditions;
-        } else {
-            this.conditions = {};
+    constructor(args: {
+        conditions?: { [id: string]: intrinsics.Expression },
+        parameters?: { [id: string]: CloudFormationParameter },
+        resources?: { [id: string]: Mapping<pulumi.Resource> },
+        pulumiMetadata?: { [cfnType: string]: PulumiResource },
+    }) {
+        this.conditions = args.conditions || {};
+        this.parameters = args.parameters || {};
+        this.resources = args.resources || {};
+        this.pulumiMetadata = args.pulumiMetadata || {};
+    }
+
+    tryFindResource(cfnType: string): PulumiResource|undefined {
+        if (this.pulumiMetadata.hasOwnProperty(cfnType)) {
+            return this.pulumiMetadata[cfnType];
         }
+    };
+
+    findParameter(parameterLogicalID: string): CloudFormationParameter | undefined {
+        if (this.parameters.hasOwnProperty(parameterLogicalID)) {
+            return this.parameters[parameterLogicalID];
+        }
+    }
+
+    evaluateParameter(param: CloudFormationParameter): intrinsics.Result<any> {
+        // Simplistic but sufficient for this test suite.
+        return this.succeed(param.Default!);
     }
 
     findCondition(conditionName: string): intrinsics.Expression|undefined {
         if (this.conditions.hasOwnProperty(conditionName)) {
             return this.conditions[conditionName];
+        }
+    }
+
+    findResourceMapping(resourceLogicalID: string): Mapping<pulumi.Resource> | undefined {
+        if (this.resources.hasOwnProperty(resourceLogicalID)) {
+            return this.resources[resourceLogicalID];
         }
     }
 


### PR DESCRIPTION
This change adds some tests and comments around the `Ref` intrinsic implementation and moves it to `intrinsics.ts`. The one change in behavior is that now `Ref` is able to consult Pulumi metadata from the `aws-native` provider. The metadata helps it resolve to the same values as it would in CloudFormation for resources that have non-standard `Ref` behavior.  The correctness of this process is up to the correctness of the metadata tables. Entries not found in the metadata tables default to using Pulumi `id` for most cases should do the right thing.

Fixes https://github.com/pulumi/pulumi-cdk/issues/173

Needs https://github.com/pulumi/pulumi-aws-native/pull/1836