### PR TITLE
chore: add removal policy to kinesis stream

### DIFF
--- a/integration/cloudfront/index.ts
+++ b/integration/cloudfront/index.ts
@@ -89,6 +89,7 @@ class CloudFrontStack extends pulumicdk.Stack {
 
         const stream = new kinesis.Stream(this, 'stream', {
             encryption: kinesis.StreamEncryption.UNENCRYPTED,
+            removalPolicy: RemovalPolicy.DESTROY,
         });
         const realtimeLogConfig = new cloudfront.RealtimeLogConfig(this, 'realtimeLog', {
             endPoints: [cloudfront.Endpoint.fromKinesisStream(stream)],

--- a/integration/kinesis/index.ts
+++ b/integration/kinesis/index.ts
@@ -1,7 +1,7 @@
 import * as pulumi from '@pulumi/pulumi';
 import * as kinesis from 'aws-cdk-lib/aws-kinesis';
 import * as pulumicdk from '@pulumi/cdk';
-import { Duration } from 'aws-cdk-lib/core';
+import { Duration, RemovalPolicy } from 'aws-cdk-lib/core';
 
 class KinesisStack extends pulumicdk.Stack {
     kinesisStreamName: pulumi.Output<string>;
@@ -12,7 +12,8 @@ class KinesisStack extends pulumicdk.Stack {
         const kStream = new kinesis.Stream(this, 'my-stream', {
             shardCount: 3,
             retentionPeriod: Duration.hours(24),
-        })
+            removalPolicy: RemovalPolicy.DESTROY,
+        });
 
         this.kinesisStreamName = this.asOutput(kStream.streamName);
     }

--- a/integration/logs/index.ts
+++ b/integration/logs/index.ts
@@ -3,6 +3,7 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import * as logs_destinations from 'aws-cdk-lib/aws-logs-destinations';
 import * as logs from 'aws-cdk-lib/aws-logs';
 import * as pulumicdk from '@pulumi/cdk';
+import { RemovalPolicy } from 'aws-cdk-lib/core';
 
 class LogsStack extends pulumicdk.Stack {
     constructor(app: pulumicdk.App, id: string, options?: pulumicdk.StackOptions) {
@@ -44,6 +45,7 @@ class LogsStack extends pulumicdk.Stack {
         });
         const stream = new kinesis.Stream(this, 'stream', {
             encryption: kinesis.StreamEncryption.UNENCRYPTED,
+            removalPolicy: RemovalPolicy.DESTROY,
         });
         logGroup2.addSubscriptionFilter('cdk-filter', {
             destination: new logs_destinations.KinesisDestination(stream),


### PR DESCRIPTION
The Kinesis Stream construct has a default policy of `Retain`. Switching to `Destroy` so the tests clean up after themselves