### PR TITLE
Add ability to specify resource options at the stack level

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ combination with CDK `fromXXX` methods.
 
 **Example**
 ```ts
+import * as pulumicdk from '@pulumi/cdk';
+import * as aws from '@pulumi/aws';
+import * as aws_route53 from 'aws-cdk-lib/aws-route53';
+
 const app = new pulumicdk.App('app', (scope: pulumicdk.App) => {
     const stack = new pulumicdk.Stack('example-stack');
 
@@ -183,6 +187,9 @@ outputs. You can do this in one of two ways.
 Any `CfnOutput` that you create automatically gets added to the `App outputs`.
 
 ```ts
+import * as pulumicdk from '@pulumi/cdk';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+
 const app = new pulumicdk.App('app', (scope: pulumicdk.App) => {
     const stack = new pulumicdk.Stack('example-stack');
     const bucket = new s3.Bucket(stack, 'Bucket');
@@ -196,6 +203,9 @@ export const bucketName = app.outputs['BucketName'];
 **AppOutputs**
 
 ```ts
+import * as pulumicdk from '@pulumi/cdk';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+
 const app = new pulumicdk.App('app', (scope: pulumicdk.App): pulumicdk.AppOutputs => {
     const stack = new pulumicdk.Stack('example-stack');
     const bucket = new s3.Bucket(stack, 'Bucket');
@@ -254,6 +264,10 @@ It is also possible to customize the Providers at the Stack level. This can be
 useful in cases where you need to deploy resources to different AWS regions.
 
 ```ts
+import * as aws from '@pulumi/aws';
+import * as ccapi from '@pulumi/aws-native';
+import * as pulumicdk from '@pulumi/cdk';
+
 const awsProvider = new aws.Provider('aws-provider');
 const awsCCAPIProvider = new ccapi.Provider('ccapi-provider', {
     // enable autoNaming
@@ -294,9 +308,13 @@ const app = new pulumicdk.App('app', (scope: pulumicdk.App) => {
 One thing to note is that when you pass different custom providers to a Stack,
 by default the Stack becomes an [environment agnostic stack](https://docs.aws.amazon.com/cdk/v2/guide/configure-env.html#configure-env-examples).
 If you want to have the environment specified at the CDK Stack level, then you
-also need to provide the environment to the Stack Props.
+also need to provide the environment to the Stack Props, as follows:
 
 ```ts
+import * as aws from '@pulumi/aws';
+import * as ccapi from '@pulumi/aws-native';
+import * as pulumicdk from '@pulumi/cdk';
+
 const app = new pulumicdk.App('app', (scope: pulumicdk.App) => {
     // inherits the provider from the app and has the CDK env auto populated
     // based on the default provider
@@ -339,6 +357,9 @@ Instead of using CDK Lookups you can use Pulumi functions along with CDK
 
 **Example**
 ```ts
+import * as pulumicdk from '@pulumi/cdk';
+import * as aws from '@pulumi/aws';
+
 const app = new pulumicdk.App('app', (scope: pulumicdk.App): pulumicdk.AppOutputs => {
     const stack = new pulumicdk.Stack('example-stack');
     // use getAmiOutput to lookup the AMI instead of ec2.LookupMachineImage
@@ -374,6 +395,9 @@ Pulumi twice (the first execution will fail).
 
 **Example**
 ```ts
+import * as pulumicdk from '@pulumi/cdk';
+import * as aws_route53 from 'aws-cdk-lib/aws-route53';
+
 const app = new pulumicdk.App('app', (scope: pulumicdk.App): pulumicdk.AppOutputs => {
     const stack = new pulumicdk.Stack('example-stack');
     const hostedZone = aws_route53.HostedZone.fromLookup(this, 'hosted-zone', {
@@ -414,6 +438,7 @@ of CDK.
 Below is an example output using Pulumi's [Compliance Ready Policies](https://www.pulumi.com/docs/iac/packages-and-automation/crossguard/compliance-ready-policies/)
 
 ```ts
+import * as pulumicdk from '@pulumi/cdk';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 
 const app = new pulumicdk.App('app', (scope: pulumicdk.App): pulumicdk.AppOutputs => {
@@ -437,6 +462,7 @@ Policies:
 Pulumi CDK supports CDK Aspects, including aspects like [cdk-nag](https://github.com/cdklabs/cdk-nag)
 
 ```ts
+import * as pulumicdk from '@pulumi/cdk';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import { AwsSolutionsChecks } from 'cdk-nag';
 
@@ -459,6 +485,7 @@ const app = new pulumicdk.App('app', (scope: pulumicdk.App): pulumicdk.AppOutput
 Pulumi CDK also supports [CDK Policy Validation Plugins](https://docs.aws.amazon.com/cdk/v2/guide/policy-validation-synthesis.html).
 
 ```ts
+import * as pulumicdk from '@pulumi/cdk';
 import { CfnGuardValidator } from '@cdklabs/cdk-validator-cfnguard';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 
@@ -529,6 +556,9 @@ a reference.
 ### Simple mapping
 
 ```ts
+import * as pulumicdk from '@pulumi/cdk';
+import * as aws from '@pulumi/aws';
+
 const app = new pulumicdk.App('app', (scope: pulumicdk.App): pulumicdk.AppOutputs => {
     const stack = new pulumicdk.Stack('example-stack');
 }, {
@@ -558,6 +588,9 @@ resources. In these cases you should return the `logicalId` of the resource
 along with the resource itself.
 
 ```ts
+import * as pulumicdk from '@pulumi/cdk';
+import * as aws from '@pulumi/aws';
+
 const app = new pulumicdk.App('app', (scope: pulumicdk.App): pulumicdk.AppOutputs => {
     const stack = new pulumicdk.Stack('example-stack');
 }, {
@@ -595,6 +628,12 @@ you create the asset. This is because Pulumi CDK will automatically create a ECR
 Repository per image asset.
 
 ```ts
+import * as pulumicdk from '@pulumi/cdk';
+import * as aws from '@pulumi/aws';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as ecs_patterns from 'aws-cdk-lib/aws-ecs-patterns';
+
 const app = new pulumicdk.App('app', (scope: pulumicdk.App) => {
     const stack = new pulumicdk.Stack('example-stack');
 
@@ -627,6 +666,8 @@ For example, if you wanted to set `protect` on database resources you could use
 a transform like this.
 
 ```ts
+import * as pulumicdk from '@pulumi/cdk';
+
 const app = new pulumicdk.App('app', (scope: pulumicdk.App): pulumicdk.AppOutputs => {
     const stack = new pulumicdk.Stack('example-stack');
 }, {
@@ -656,13 +697,16 @@ In order to customize the settings, you can pass in a `PulumiSynthesizer` that
 you create.
 
 ```ts
+import * as pulumicdk from '@pulumi/cdk';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+
 const app = new pulumicdk.App('app', (scope: pulumicdk.App) => {
     const stack = new pulumicdk.Stack('example-stack');
     const bucket = new s3.Bucket(stack, 'Bucket');
 }, {
   appOptions: {
     props: {
-      defaultStackSynthesizer: new PulumiSynthesizer({
+      defaultStackSynthesizer: new pulumicdk.PulumiSynthesizer({
         appId: `cdk-${pulumi.getStack()}`,
         autoDeleteStagingAssets: false,
       })
@@ -703,7 +747,10 @@ default. If you _are_ configuring your own `aws-native` provider then you will
 have to enable this.
 
 ```ts
-const nativeProvider = new aws_native.Provider('cdk-native-provider', {
+import * as pulumicdk from '@pulumi/cdk';
+import * as ccapi from '@pulumi/aws-native';
+
+const nativeProvider = new ccapi.Provider('cdk-native-provider', {
   region: 'us-east-2',
   autoNaming: {
     autoTrim: true,

--- a/api-docs/README.md
+++ b/api-docs/README.md
@@ -297,7 +297,7 @@ new App('testapp', (scope: App) => {
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| `props?` | `StackProps` | The CDK Stack props | [stack.ts:295](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L295) |
+| `props?` | `StackProps` | The CDK Stack props | [stack.ts:297](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L297) |
 
 ## Type Aliases
 

--- a/api-docs/README.md
+++ b/api-docs/README.md
@@ -83,6 +83,37 @@ export const bucket = app.outputs['bucket'];
 | `name` | `readonly` | `string` | `undefined` | The name of the component | [stack.ts:57](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L57) |
 | `outputs` | `public` | `object` | `{}` | The collection of outputs from the AWS CDK Stack represented as Pulumi Outputs. Each CfnOutput defined in the AWS CDK Stack will populate a value in the outputs. | [stack.ts:63](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L63) |
 
+#### Accessors
+
+##### env
+
+###### Get Signature
+
+> **get** **env**(): `Environment`
+
+This can be used to get the CDK Environment based on the Pulumi Provider used for the App.
+You can then use this to configure an explicit environment on Stacks.
+
+###### Example
+
+```ts
+const app = new pulumicdk.App('app', (scope: pulumicdk.App) => {
+    const stack = new pulumicdk.Stack(scope, 'pulumi-stack', {
+        props: { env: app.env },
+    });
+});
+```
+
+###### Returns
+
+`Environment`
+
+the CDK Environment configured for the App
+
+###### Defined in
+
+[stack.ts:155](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L155)
+
 ***
 
 ### Stack
@@ -121,7 +152,7 @@ Create and register an AWS CDK stack deployed with Pulumi.
 
 ###### Defined in
 
-[stack.ts:330](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L330)
+[stack.ts:336](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L336)
 
 #### Methods
 
@@ -151,7 +182,7 @@ A Pulumi Output value.
 
 ###### Defined in
 
-[stack.ts:432](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L432)
+[stack.ts:418](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L418)
 
 ## Interfaces
 
@@ -266,7 +297,7 @@ new App('testapp', (scope: App) => {
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| `props?` | `StackProps` | The CDK Stack props | [stack.ts:289](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L289) |
+| `props?` | `StackProps` | The CDK Stack props | [stack.ts:295](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L295) |
 
 ## Type Aliases
 

--- a/api-docs/README.md
+++ b/api-docs/README.md
@@ -74,14 +74,14 @@ export const bucket = app.outputs['bucket'];
 
 ###### Defined in
 
-[stack.ts:96](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L96)
+[stack.ts:105](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L105)
 
 #### Properties
 
 | Property | Modifier | Type | Default value | Description | Defined in |
 | ------ | ------ | ------ | ------ | ------ | ------ |
-| `name` | `readonly` | `string` | `undefined` | The name of the component | [stack.ts:55](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L55) |
-| `outputs` | `public` | `object` | `{}` | The collection of outputs from the AWS CDK Stack represented as Pulumi Outputs. Each CfnOutput defined in the AWS CDK Stack will populate a value in the outputs. | [stack.ts:61](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L61) |
+| `name` | `readonly` | `string` | `undefined` | The name of the component | [stack.ts:57](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L57) |
+| `outputs` | `public` | `object` | `{}` | The collection of outputs from the AWS CDK Stack represented as Pulumi Outputs. Each CfnOutput defined in the AWS CDK Stack will populate a value in the outputs. | [stack.ts:63](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L63) |
 
 ***
 
@@ -121,7 +121,7 @@ Create and register an AWS CDK stack deployed with Pulumi.
 
 ###### Defined in
 
-[stack.ts:264](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L264)
+[stack.ts:330](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L330)
 
 #### Methods
 
@@ -151,7 +151,7 @@ A Pulumi Output value.
 
 ###### Defined in
 
-[stack.ts:277](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L277)
+[stack.ts:432](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L432)
 
 ## Interfaces
 
@@ -233,6 +233,31 @@ Options specific to the Pulumi CDK App component.
 
 Options for creating a Pulumi CDK Stack
 
+Any Pulumi resource options provided at the Stack level will override those configured
+at the App level
+
+#### Example
+
+```ts
+new App('testapp', (scope: App) => {
+    // This stack will inherit the options from the App
+    new Stack(scope, 'teststack1');
+
+   // Override the options for this stack
+   new Stack(scope, 'teststack', {
+       providers: [
+         new native.Provider('custom-provider', { region: 'us-east-1' }),
+       ],
+       props: { env: { region: 'us-east-1' } },
+   })
+}, {
+     providers: [
+         new native.Provider('app-provider', { region: 'us-west-2' }),
+     ]
+
+})
+```
+
 #### Extends
 
 - `ComponentResourceOptions`
@@ -241,7 +266,7 @@ Options for creating a Pulumi CDK Stack
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| `props?` | `StackProps` | The CDK Stack props | [stack.ts:230](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L230) |
+| `props?` | `StackProps` | The CDK Stack props | [stack.ts:289](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L289) |
 
 ## Type Aliases
 
@@ -255,7 +280,7 @@ Options for creating a Pulumi CDK Stack
 
 #### Defined in
 
-[stack.ts:24](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L24)
+[stack.ts:26](https://github.com/pulumi/pulumi-cdk/blob/main/src/stack.ts#L26)
 
 ## Functions
 

--- a/examples/lookups-enabled/index.ts
+++ b/examples/lookups-enabled/index.ts
@@ -1,4 +1,3 @@
-import * as aws from '@pulumi/aws';
 import * as pulumi from '@pulumi/pulumi';
 import * as pulumicdk from '@pulumi/cdk';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
@@ -12,14 +11,12 @@ import {
 
 const config = new pulumi.Config();
 const zoneName = config.require('zoneName');
-const accountId = config.require('accountId');
-const region = aws.config.requireRegion();
 
 export class Ec2CdkStack extends pulumicdk.Stack {
     constructor(app: pulumicdk.App, id: string) {
         super(app, id, {
             props: {
-                env: { region, account: accountId },
+                env: app.env,
             },
         });
 

--- a/examples/stack-provider/Pulumi.yaml
+++ b/examples/stack-provider/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-stack-provider
+runtime: nodejs
+description: A minimal TypeScript Pulumi program

--- a/examples/stack-provider/index.ts
+++ b/examples/stack-provider/index.ts
@@ -1,0 +1,70 @@
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as pulumi from '@pulumi/pulumi';
+import * as pulumicdk from '@pulumi/cdk';
+import * as native from '@pulumi/aws-native';
+import { RemovalPolicy } from 'aws-cdk-lib';
+
+const config = new pulumi.Config();
+const cdkRegion = config.get('cdk-region');
+const cdkAccount = config.get('cdk-account');
+const defaultRegion = config.get('default-region');
+
+export class StackProviderStack extends pulumicdk.Stack {
+    public readonly logsRegion: pulumi.Output<string>;
+    constructor(app: pulumicdk.App, id: string, providers?: pulumi.ProviderResource[]) {
+        super(app, id, {
+            providers,
+            props:
+                cdkRegion || cdkAccount
+                    ? {
+                          env: {
+                              region: cdkRegion,
+                              account: cdkAccount,
+                          },
+                      }
+                    : undefined,
+        });
+
+        const group = new logs.LogGroup(this, 'group', {
+            retention: logs.RetentionDays.ONE_DAY,
+            removalPolicy: RemovalPolicy.DESTROY,
+        });
+
+        this.logsRegion = this.asOutput(group.logGroupArn).apply((arn) => arn.split(':')[3]);
+    }
+}
+
+const app = new pulumicdk.App(
+    'app',
+    (scope: pulumicdk.App) => {
+        const stack = new StackProviderStack(scope, 'teststack', [
+            new native.Provider('ccapi-provider', {
+                region: 'us-east-1', // a different region from the app provider
+            }),
+        ]);
+        const defaultStack = new StackProviderStack(scope, 'default-stack');
+        return {
+            east1LogsRegion: stack.logsRegion,
+            east1StackRegion: stack.asOutput(stack.region),
+            defaultLogsRegion: defaultStack.logsRegion,
+            defaultStackRegion: defaultStack.asOutput(defaultStack.region),
+        };
+    },
+    {
+        providers: defaultRegion
+            ? [
+                  new native.Provider('app-provider', {
+                      region: defaultRegion as native.Region, // a different region from the default env
+                  }),
+              ]
+            : undefined,
+    },
+);
+
+// You can (we check for this though) configure a different region on the provider
+// that the stack uses vs the region in the CDK StackProps. This tests checks that both the
+// stack region and the region the resources are deployed to are the same.
+export const east1LogsRegion = app.outputs['east1LogsRegion'];
+export const defaultLogsRegion = app.outputs['defaultLogsRegion'];
+export const east1StackRegion = app.outputs['east1StackRegion'];
+export const defaultStackRegion = app.outputs['defaultStackRegion'];

--- a/examples/stack-provider/package.json
+++ b/examples/stack-provider/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "pulumi-aws-cdk",
+    "devDependencies": {
+        "@types/node": "^10.0.0"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/aws-native": "^1.9.0",
+        "@pulumi/cdk": "^0.5.0",
+        "aws-cdk-lib": "2.156.0",
+        "constructs": "10.3.0"
+    }
+}

--- a/examples/stack-provider/tsconfig.json
+++ b/examples/stack-provider/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/src/converters/app-converter.ts
+++ b/src/converters/app-converter.ts
@@ -99,6 +99,7 @@ export class StackConverter extends ArtifactConverter implements intrinsics.Intr
     readonly resources = new Map<string, Mapping<pulumi.Resource>>();
     readonly constructs = new Map<ConstructInfo, pulumi.Resource>();
     private readonly cdkStack: cdk.Stack;
+    private readonly stackOptions?: pulumi.ComponentResourceOptions;
 
     private _stackResource?: CdkConstruct;
     private readonly graph: Graph;
@@ -113,6 +114,7 @@ export class StackConverter extends ArtifactConverter implements intrinsics.Intr
     constructor(host: AppComponent, readonly stack: StackManifest) {
         super(host);
         this.cdkStack = host.stacks[stack.id];
+        this.stackOptions = host.stackOptions[stack.id];
         this.graph = GraphBuilder.build(this.stack);
     }
 
@@ -125,6 +127,7 @@ export class StackConverter extends ArtifactConverter implements intrinsics.Intr
         for (const n of this.graph.nodes) {
             if (n.construct.id === this.stack.id) {
                 this._stackResource = new CdkConstruct(`${this.app.name}/${n.construct.path}`, n.construct.id, {
+                    ...this.stackOptions,
                     parent: this.app.component,
                     // NOTE: Currently we make the stack depend on all the assets and then all resources
                     // have the parent as the stack. This means we deploy all assets before we deploy any resources
@@ -664,18 +667,18 @@ export class StackConverter extends ArtifactConverter implements intrinsics.Intr
     }
 
     getAccountId(): intrinsics.Result<string> {
-        return getAccountId({ parent: this.app.component }).then((r) => r.accountId);
+        return getAccountId({ parent: this.stackResource }).then((r) => r.accountId);
     }
 
     getRegion(): intrinsics.Result<string> {
-        return getRegion({ parent: this.app.component }).then((r) => r.region);
+        return getRegion({ parent: this.stackResource }).then((r) => r.region);
     }
 
     getPartition(): intrinsics.Result<string> {
-        return getPartition({ parent: this.app.component }).then((p) => p.partition);
+        return getPartition({ parent: this.stackResource }).then((p) => p.partition);
     }
 
     getURLSuffix(): intrinsics.Result<string> {
-        return getUrlSuffix({ parent: this.app.component }).then((r) => r.urlSuffix);
+        return getUrlSuffix({ parent: this.stackResource }).then((r) => r.urlSuffix);
     }
 }

--- a/src/converters/artifact-converter.ts
+++ b/src/converters/artifact-converter.ts
@@ -1,5 +1,3 @@
-import * as cx from 'aws-cdk-lib/cx-api';
-import { getAccountId, getPartition, getRegion } from '@pulumi/aws-native';
 import { AppComponent } from '../types';
 
 /**
@@ -7,27 +5,4 @@ import { AppComponent } from '../types';
  */
 export abstract class ArtifactConverter {
     constructor(protected readonly app: AppComponent) {}
-
-    /**
-     * Takes a string and resolves any CDK environment placeholders (e.g. accountId, region, partition)
-     *
-     * @param s - The string that contains the placeholders to replace
-     * @returns The string with the placeholders fully resolved
-     */
-    protected resolvePlaceholders(s: string): Promise<string> {
-        const host = this.app;
-        return cx.EnvironmentPlaceholders.replaceAsync(s, {
-            async region(): Promise<string> {
-                return getRegion({ parent: host.component }).then((r) => r.region);
-            },
-
-            async accountId(): Promise<string> {
-                return getAccountId({ parent: host.component }).then((r) => r.accountId);
-            },
-
-            async partition(): Promise<string> {
-                return getPartition({ parent: host.component }).then((p) => p.partition);
-            },
-        });
-    }
 }

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 import * as cdk from 'aws-cdk-lib/core';
 import * as pulumi from '@pulumi/pulumi';
+import * as aws from '@pulumi/aws';
 import { AppComponent, AppOptions, AppResourceOptions } from './types';
 import { AppConverter, StackConverter } from './converters/app-converter';
 import { PulumiSynthesizer, PulumiSynthesizerBase } from './synthesizer';
@@ -20,6 +21,7 @@ import { AwsCdkCli, ICloudAssemblyDirectoryProducer } from '@aws-cdk/cli-lib-alp
 import { CdkConstruct } from './interop';
 import { makeUniqueId } from './cdk-logical-id';
 import * as native from '@pulumi/aws-native';
+import { warn } from '@pulumi/pulumi/log';
 
 export type AppOutputs = { [outputId: string]: pulumi.Output<any> };
 
@@ -70,6 +72,12 @@ export class App
      */
     public readonly stacks: { [artifactId: string]: cdk.Stack } = {};
 
+    /**
+     * The Pulumi ComponentResourceOptions associated with the stack
+     * @internal
+     */
+    readonly stackOptions: { [artifactId: string]: pulumi.ComponentResourceOptions } = {};
+
     /** @internal */
     public converter: Promise<AppConverter>;
 
@@ -91,6 +99,7 @@ export class App
 
     private readonly createFunc: (scope: App) => AppOutputs | void;
     private _app?: cdk.App;
+    private _env?: cdk.Environment;
     private appProps?: cdk.AppProps;
 
     constructor(id: string, createFunc: (scope: App) => void | AppOutputs, props?: AppResourceOptions) {
@@ -131,13 +140,27 @@ export class App
     }
 
     /**
+     * Because the app creates CDK Stacks in an async function, we can grab the
+     * environment from the AWS CCAPI provider used by the App and make that available
+     * as the CDK Environment for the Stacks.
+     *
+     * @internal
+     */
+    public get env(): cdk.Environment {
+        if (!this._env) {
+            throw new Error('cdk.Environment has not been created yet');
+        }
+        return this._env;
+    }
+
+    /**
      * @internal
      */
     public get app(): cdk.App {
         if (!this._app) {
             throw new Error('cdk.App has not been created yet');
         }
-        return this._app!;
+        return this._app;
     }
 
     protected async initialize(props: {
@@ -150,6 +173,17 @@ export class App
         this.appOptions = props.args;
         const lookupsEnabled = process.env.PULUMI_CDK_EXPERIMENTAL_LOOKUPS === 'true';
         const lookups = lookupsEnabled && pulumi.runtime.isDryRun();
+        const account = await native
+            .getAccountId({
+                parent: this,
+                ...props.opts,
+            })
+            .then((account) => account.accountId);
+        const region = await native.getRegion({ parent: this, ...props.opts }).then((region) => region.region);
+        this._env = {
+            account,
+            region,
+        };
         try {
             // TODO: support lookups https://github.com/pulumi/pulumi-cdk/issues/184
             await cli.synth({ quiet: true, lookups });
@@ -211,6 +245,9 @@ export class App
         app.node.children.forEach((child) => {
             if (Stack.isPulumiStack(child)) {
                 this.stacks[child.artifactId] = child;
+                if (child.options) {
+                    this.stackOptions[child.artifactId] = child.options;
+                }
             }
         });
 
@@ -222,6 +259,28 @@ export class App
 
 /**
  * Options for creating a Pulumi CDK Stack
+ *
+ * Any Pulumi resource options provided at the Stack level will override those configured
+ * at the App level
+ *
+ * @example
+ * new App('testapp', (scope: App) => {
+ *     // This stack will inherit the options from the App
+ *     new Stack(scope, 'teststack1');
+ *
+ *    // Override the options for this stack
+ *    new Stack(scope, 'teststack', {
+ *        providers: [
+ *          new native.Provider('custom-provider', { region: 'us-east-1' }),
+ *        ],
+ *        props: { env: { region: 'us-east-1' } },
+ *    })
+ * }, {
+ *      providers: [
+ *          new native.Provider('app-provider', { region: 'us-west-2' }),
+ *      ]
+ *
+ * })
  */
 export interface StackOptions extends pulumi.ComponentResourceOptions {
     /**
@@ -229,6 +288,8 @@ export interface StackOptions extends pulumi.ComponentResourceOptions {
      */
     props?: cdk.StackProps;
 }
+
+type Writeable<T> = { -readonly [P in keyof T]: T[P] };
 
 /**
  * A Construct that represents an AWS CDK stack deployed with Pulumi.
@@ -256,16 +317,110 @@ export class Stack extends cdk.Stack {
     public converter: Promise<StackConverter>;
 
     /**
+     * @internal
+     */
+    public options?: pulumi.ComponentResourceOptions;
+
+    /**
      * Create and register an AWS CDK stack deployed with Pulumi.
      *
      * @param name The _unique_ name of the resource.
      * @param options A bag of options that control this resource's behavior.
      */
-    constructor(app: App, name: string, options?: StackOptions) {
-        super(app.app, name, options?.props);
+    constructor(private readonly app: App, name: string, options?: StackOptions) {
+        const env: Writeable<cdk.Environment> = options?.props?.env ?? {};
+        const hasNativeProvider = hasProvider(options?.providers, (p) => native.Provider.isInstance(p));
+
+        if (!env.account && !hasNativeProvider) {
+            env.account = app.env.account;
+        }
+
+        // if the user has provided a separate native provider to the stack
+        // then we don't want to set the region from the app provider. The stack will
+        // be an environment agnostic (and determine the region  from the provider) unless
+        // they provide a region to the stack props.
+        if (!env.region && !hasNativeProvider) {
+            env.region = app.env.region;
+        }
+
+        super(app.app, name, {
+            // set the env based on the credentials of the App
+            // but allow the user to override it
+            ...options?.props,
+            env: env,
+        });
         Object.defineProperty(this, STACK_SYMBOL, { value: true });
 
+        this.options = options;
         this.converter = app.converter.then((converter) => converter.stacks.get(this.artifactId)!);
+
+        this.validateEnv();
+    }
+
+    /**
+     * This function validates that the user has correctly configured the stack environment. There are two
+     * ways that the environment comes into play in a Pulumi CDK application. When resources are created
+     * they are created with a specific provider that is either inherited from the Stack or the App. There
+     * are some values though that CDK generates based on what environment is passed to the StackProps.
+     *
+     * Below is an example of something a user could configure (by mistake).
+     *
+     * @example
+     * new App('testapp', (scope: App) => {
+     *    new Stack(scope, 'teststack', {
+     *        providers: [
+     *          new native.Provider('native-provider', { region: 'us-east-1' }),
+     *        ],
+     *        props: { env: { region: 'us-east-2' }},
+     *    })
+     * }, {
+     *      providers: [
+     *          new native.Provider('native-provider', { region: 'us-west-2' }),
+     *      ]
+     *
+     * })
+     */
+    private validateEnv(): void {
+        const providers = providersToArray(this.options?.providers);
+        const nativeProvider = providers.find((p) => native.Provider.isInstance(p));
+        const awsProvider = providers.find((p) => aws.Provider.isInstance(p));
+
+        const awsRegion = aws.getRegionOutput({}, { parent: this.app, provider: awsProvider }).name;
+        const awsAccount = aws.getCallerIdentityOutput({}, { parent: this.app, provider: awsProvider }).accountId;
+        const nativeRegion = native.getRegionOutput({ parent: this.app, provider: nativeProvider }).region;
+        const nativeAccount = native.getAccountIdOutput({ parent: this.app, provider: nativeProvider }).accountId;
+
+        pulumi
+            .all([awsRegion, awsAccount, nativeRegion, nativeAccount])
+            .apply(([awsRegion, awsAccount, nativeRegion, nativeAccount]) => {
+                // This is to ensure that the user does not pass a different region to the provider and the stack environment.
+                if (!cdk.Token.isUnresolved(this.region) && nativeRegion !== this.region) {
+                    throw new Error(
+                        `The stack '${this.node.id}' has conflicting regions between the native provider (${nativeRegion}) and the stack environment (${this.region}).\n` +
+                            'Please ensure that the stack environment region matches the region of the native provider.',
+                    );
+                }
+
+                if (!cdk.Token.isUnresolved(this.account) && this.account !== nativeAccount) {
+                    throw new Error(
+                        `The stack '${this.node.id}' has conflicting accounts between the native provider (${nativeAccount}) and the stack environment (${this.account}).\n` +
+                            'Please ensure that the stack environment account matches the account of the native provider.',
+                    );
+                }
+
+                if (nativeAccount !== awsAccount) {
+                    warn(
+                        `The stack '${this.node.id}' uses different accounts for the AWS Provider (${awsAccount}) and the AWS CCAPI Provider (${nativeAccount}). This may be a misconfiguration.`,
+                        this.app,
+                    );
+                }
+                if (nativeRegion !== awsRegion) {
+                    warn(
+                        `The stack '${this.node.id}' uses different regions for the AWS Provider (${awsRegion}) and the AWS CCAPI Provider (${nativeRegion}). This may be a misconfiguration.`,
+                        this.app,
+                    );
+                }
+            });
     }
 
     /**
@@ -336,6 +491,22 @@ function generateAppId(): string {
         .slice(-17);
 }
 
+function hasProvider(
+    providers: pulumi.ProviderResource[] | Record<string, pulumi.ProviderResource> | undefined,
+    compareFn: (resource: pulumi.ProviderResource) => boolean,
+): boolean {
+    if (!providers) {
+        return false;
+    }
+    return providersToArray(providers).some(compareFn);
+}
+
+function providersToArray(
+    providers: pulumi.ProviderResource[] | Record<string, pulumi.ProviderResource> | undefined,
+): pulumi.ProviderResource[] {
+    return providers && !Array.isArray(providers) ? Object.values(providers) : providers ?? [];
+}
+
 /**
  * If the user has not provided the aws-native provider, we will create one by default in order
  * to enable the autoNaming feature.
@@ -347,7 +518,7 @@ function createDefaultNativeProvider(
     // will throw an error
     const region = native.config.region ?? process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION!;
 
-    const newProviders = providers && !Array.isArray(providers) ? Object.values(providers) : providers ?? [];
+    const newProviders = providersToArray(providers);
     if (!newProviders.find((p) => native.Provider.isInstance(p))) {
         newProviders.push(
             new native.Provider('cdk-aws-native', {

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,12 @@ export interface AppComponent {
     readonly stacks: { [artifactId: string]: Stack };
 
     /**
+     * The Pulumi ComponentResourceOptions associated with the stack
+     * @internal
+     */
+    readonly stackOptions: { [artifactId: string]: pulumi.ComponentResourceOptions };
+
+    /**
      * The underlying ComponentResource
      * @internal
      */

--- a/tests/cdk-resource.test.ts
+++ b/tests/cdk-resource.test.ts
@@ -137,7 +137,7 @@ describe('CDK Construct tests', () => {
                     {
                         Action: 'events:PutEvents',
                         Effect: 'Allow',
-                        Principal: { AWS: 'arn:aws:iam::12345678912:root' },
+                        Principal: { AWS: 'arn:aws:iam::12345678910:root' },
                         Resource: 'testbus_arn',
                         Sid: 'cdk-testsid',
                     },

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -1,3 +1,4 @@
+import * as native from '@pulumi/aws-native';
 import * as pulumi from '@pulumi/pulumi';
 import { StackManifest } from '../src/assembly';
 import { StackConverter } from '../src/converters/app-converter';
@@ -251,6 +252,66 @@ describe('options', () => {
             expect.anything(),
             expect.not.objectContaining({
                 retainOnDelete: false,
+            }),
+        );
+    });
+
+    test('provider can be set at stack level', async () => {
+        const manifest = new StackManifest({
+            id: 'stack',
+            templatePath: 'test/stack',
+            metadata: {
+                'stack/bucket': 'bucket',
+            },
+            tree: {
+                path: 'stack',
+                id: 'stack',
+                children: {
+                    bucket: {
+                        id: 'bucket',
+                        path: 'stack/bucket',
+                        attributes: {
+                            'aws:cdk:cloudformation:type': 'AWS::S3::Bucket',
+                        },
+                    },
+                },
+                constructInfo: {
+                    fqn: 'aws-cdk-lib.Stack',
+                    version: '2.149.0',
+                },
+            },
+            template: {
+                Resources: {
+                    bucket: {
+                        Type: 'AWS::S3::Bucket',
+                        Properties: {},
+                    },
+                },
+            },
+            dependencies: [],
+        });
+        const appComponent = new MockAppComponent('/tmp/foo/bar/does/not/exist');
+
+        appComponent.stackOptions['stack'] = {
+            providers: [
+                new native.Provider('test-native', {
+                    region: 'us-west-2',
+                }),
+            ],
+        };
+        const converter = new StackConverter(appComponent, manifest);
+        converter.convert(new Set());
+        expect(pulumi.CustomResource).toHaveBeenCalledWith(
+            'aws-native:s3:Bucket',
+            'bucket',
+            expect.anything(),
+            expect.objectContaining({
+                parent: expect.objectContaining({
+                    __name: 'stack/stack',
+                    __providers: expect.objectContaining({
+                        'aws-native': expect.objectContaining({ __name: 'test-native' }),
+                    }),
+                }),
             }),
         );
     });


### PR DESCRIPTION
It has been possible to specify Pulumi resource options at the stack level, but it did not flow through to the actual resources. This PR makes sure that the inheritance works correctly.

This PR also adds functionality to automatically set the Stack environment based on the App provider. Because the App creates the stacks in an async context, we can use provider functions to lookup the environment and then pass the resolved environment to the stack. 

For now this is something that the user will have to specify (example in the `lookups` example test). This would mean that all Stacks have their environment provided by default. This will cut down on the number of Intrinsics used in the generated template. The reason I am not turning this on by default is because it requires lookups to be enabled (environment agnostic stacks use Intrinsics to find availability zones, but explicit environment stacks use lookups).

If the user provides a provider to the Stack we are no longer in an async context which means we can't determine the environment from the provider and fall back to an environment agnostic stack.

re #61, re #219