### PR TITLE
chore: add example of looking up availability zones

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -325,6 +325,22 @@ func TestAPIWebsocketLambdaDynamoDB(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestLookupAzs(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: filepath.Join(getCwd(t), "lookup-azs"),
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				t.Helper()
+				t.Logf("Outputs: %v", stack.Outputs)
+				azs := stack.Outputs["azs"].([]interface{})
+				// by default the CDK will use 2 AZs so this makes sure our logic is working
+				assert.Lenf(t, azs, 3, "Expected 2 AZs, got %d", len(azs))
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	base := getBaseOptions(t)
 	baseJS := base.With(integration.ProgramTestOptions{

--- a/examples/lookup-azs/Pulumi.yaml
+++ b/examples/lookup-azs/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-aws-cdk-lookups-azs
+runtime: nodejs
+description: lookup azs example for CDK

--- a/examples/lookup-azs/index.ts
+++ b/examples/lookup-azs/index.ts
@@ -1,9 +1,11 @@
 import * as pulumicdk from '@pulumi/cdk';
-
+import * as pulumi from '@pulumi/pulumi';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import { Fn } from 'aws-cdk-lib';
 import { Output } from '@pulumi/pulumi';
 
+const config = new pulumi.Config();
+const prefix = config.get('prefix') ?? pulumi.getStack();
 class LookupAzsStack extends pulumicdk.Stack {
     public readonly azs: Output<string[]>;
     constructor(app: pulumicdk.App, id: string) {
@@ -27,7 +29,7 @@ class LookupAzsStack extends pulumicdk.Stack {
 class MyApp extends pulumicdk.App {
     constructor() {
         super('app', (scope: pulumicdk.App): pulumicdk.AppOutputs => {
-            const stack = new LookupAzsStack(scope, 'fargatestack');
+            const stack = new LookupAzsStack(scope, `${prefix}-azs`);
             return {
                 azs: stack.azs,
             };

--- a/examples/lookup-azs/index.ts
+++ b/examples/lookup-azs/index.ts
@@ -1,0 +1,39 @@
+import * as pulumicdk from '@pulumi/cdk';
+
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import { Fn } from 'aws-cdk-lib';
+import { Output } from '@pulumi/pulumi';
+
+class LookupAzsStack extends pulumicdk.Stack {
+    public readonly azs: Output<string[]>;
+    constructor(app: pulumicdk.App, id: string) {
+        super(app, id, {
+            props: { env: app.env },
+        });
+
+        const vpc = new ec2.Vpc(this, 'MyVpc', { maxAzs: 3 });
+        this.azs = this.asOutput(vpc.availabilityZones);
+    }
+
+    // You can override the availabilityZones property to perform a lookup.
+    // Here I have specified that I want 3 availability zones. This uses Intrinsics, which
+    // behind the scenes are backed by Pulumi functions (e.g. aws_native.getAzs()).
+    // This allows us to get around the limitation of not being able to use Output values here.
+    get availabilityZones(): string[] {
+        return [Fn.select(0, Fn.getAzs()), Fn.select(1, Fn.getAzs()), Fn.select(2, Fn.getAzs())];
+    }
+}
+
+class MyApp extends pulumicdk.App {
+    constructor() {
+        super('app', (scope: pulumicdk.App): pulumicdk.AppOutputs => {
+            const stack = new LookupAzsStack(scope, 'fargatestack');
+            return {
+                azs: stack.azs,
+            };
+        });
+    }
+}
+
+const app = new MyApp();
+export const azs = app.outputs['azs'];

--- a/examples/lookup-azs/package.json
+++ b/examples/lookup-azs/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "pulumi-aws-cdk",
+    "devDependencies": {
+        "@types/node": "^10.0.0"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/aws-native": "^1.9.0",
+        "@pulumi/cdk": "^0.5.0",
+        "@pulumi/docker-build": "^0.0.7",
+        "@pulumi/pulumi": "^3.0.0",
+        "@types/express": "^5.0.0",
+        "aws-cdk-lib": "2.156.0",
+        "constructs": "10.3.0",
+        "esbuild": "^0.24.0",
+        "express": "^4.21.1"
+    }
+}

--- a/examples/lookup-azs/tsconfig.json
+++ b/examples/lookup-azs/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
If you provide an explicit environment to the stack (there are a lot of
reasons to do this) then you have to enable lookups in order for the
stack to lookup the availability zones.

It would be nice if you could just use Pulumi functions to lookup the
AZs and provide that, but the values have to be strings (can't be
promises/outputs). An easy workaround for this is to use the `getAzs`
intrinsic to defer the lookup and allow the intrinsic to be converted to
a Pulumi function.

I am adding an example of how to do this. The reason we don't want to do
this by default is that the number of availability zones is not
something that should every change without the user knowing about it.
CDK handles that by having the lookup store the value in the
`cdk.context.json` file so the lookup is never re-run.