### PR TITLE
Do not use Ref metadata for AWS Provider resources

### DIFF
--- a/src/aws-resource-mappings.ts
+++ b/src/aws-resource-mappings.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import * as pulumi from '@pulumi/pulumi';
-import { getAttributesFromResource } from './types';
 import * as aws from '@pulumi/aws';
 import { ResourceAttributeMappingArray, ResourceMapping, normalize } from './interop';
 
@@ -52,7 +51,7 @@ export function mapToAwsResource(
     switch (typeName) {
         // ApiGatewayV2
         case 'AWS::ApiGatewayV2::Integration': {
-            const resource = new aws.apigatewayv2.Integration(
+            return new aws.apigatewayv2.Integration(
                 logicalId,
                 {
                     ...props,
@@ -63,13 +62,6 @@ export function mapToAwsResource(
                 },
                 options,
             );
-            return {
-                resource,
-                attributes: {
-                    ...getAttributesFromResource(resource),
-                    id: resource.id,
-                },
-            };
         }
         case 'AWS::ApiGatewayV2::Stage':
             return new aws.apigatewayv2.Stage(

--- a/src/converters/intrinsics.ts
+++ b/src/converters/intrinsics.ts
@@ -394,6 +394,14 @@ function evaluateRef(ctx: IntrinsicContext, param: string): Result<any> {
             // Custom resources have a `physicalResourceId` that is used for Ref
             return ctx.succeed(map.resource.physicalResourceId);
         }
+
+        const pType = (<any>map.resource).__pulumiType;
+        if (!pType.startsWith('aws-native:')) {
+            // For non-aws-native resources (i.e. AWS Provider), fallback to using the id
+            // if this is incorrect users will have to provide a mapping with the correct id
+            const cr = <pulumi.CustomResource>map.resource; // assume we have a custom resource.
+            return ctx.succeed(cr.id);
+        }
         const resMeta = ctx.tryFindResource(map.resourceType);
 
         // If there is no metadata to suggest otherwise, assume that we can use the Pulumi id which typically will be

--- a/tests/converters/intrinsics.test.ts
+++ b/tests/converters/intrinsics.test.ts
@@ -1,23 +1,25 @@
-import * as aws from '@pulumi/aws-native';
+import * as ccapi from '@pulumi/aws-native';
+import * as aws from '@pulumi/aws';
 import * as pulumi from '@pulumi/pulumi';
 import * as intrinsics from '../../src/converters/intrinsics';
 import {
     CloudFormationParameter,
     CloudFormationParameterLogicalId,
-    CloudFormationParameterWithId
+    CloudFormationParameterWithId,
 } from '../../src/cfn';
 import { Mapping } from '../../src/types';
 import { PulumiResource } from '../../src/pulumi-metadata';
+import { OutputRepr } from '../../src/output-map';
 
 describe('Fn::If', () => {
     test('picks true', async () => {
-        const tc = new TestContext({conditions: {'MyCondition': true}});
+        const tc = new TestContext({ conditions: { MyCondition: true } });
         const result = runIntrinsic(intrinsics.fnIf, tc, ['MyCondition', 'yes', 'no']);
         expect(result).toEqual(ok('yes'));
     });
 
     test('picks false', async () => {
-        const tc = new TestContext({conditions: {'MyCondition': false}});
+        const tc = new TestContext({ conditions: { MyCondition: false } });
         const result = runIntrinsic(intrinsics.fnIf, tc, ['MyCondition', 'yes', 'no']);
         expect(result).toEqual(ok('no'));
     });
@@ -29,7 +31,7 @@ describe('Fn::If', () => {
     });
 
     test('errors if condition evaluates to a non-boolean', async () => {
-        const tc = new TestContext({conditions: {'MyCondition': 'OOPS'}});
+        const tc = new TestContext({ conditions: { MyCondition: 'OOPS' } });
         const result = runIntrinsic(intrinsics.fnIf, tc, ['MyCondition', 'yes', 'no']);
         expect(result).toEqual(failed(`Expected a boolean, got string`));
     });
@@ -49,14 +51,14 @@ describe('Fn::Or', () => {
     });
 
     test('picks true from inner Condition', async () => {
-        const tc = new TestContext({conditions: {'MyCondition': true}});
-        const result = runIntrinsic(intrinsics.fnOr, tc, [false, {'Condition': 'MyCondition'}]);
+        const tc = new TestContext({ conditions: { MyCondition: true } });
+        const result = runIntrinsic(intrinsics.fnOr, tc, [false, { Condition: 'MyCondition' }]);
         expect(result).toEqual(ok(true));
     });
 
     test('picks false with inner Condition', async () => {
-        const tc = new TestContext({conditions: {'MyCondition': false}});
-        const result = runIntrinsic(intrinsics.fnOr, tc, [false, {'Condition': 'MyCondition'}]);
+        const tc = new TestContext({ conditions: { MyCondition: false } });
+        const result = runIntrinsic(intrinsics.fnOr, tc, [false, { Condition: 'MyCondition' }]);
         expect(result).toEqual(ok(false));
     });
 
@@ -68,10 +70,10 @@ describe('Fn::Or', () => {
 
     test('short-cirtcuits evaluation if true is found', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnOr, tc, [true, {'Condition': 'DoesNotExist'}]);
+        const result = runIntrinsic(intrinsics.fnOr, tc, [true, { Condition: 'DoesNotExist' }]);
         expect(result).toEqual(ok(true));
     });
-})
+});
 
 describe('Fn::And', () => {
     test('picks true', async () => {
@@ -87,14 +89,14 @@ describe('Fn::And', () => {
     });
 
     test('picks true from inner Condition', async () => {
-        const tc = new TestContext({conditions: {'MyCondition': true}});
-        const result = runIntrinsic(intrinsics.fnAnd, tc, [true, {'Condition': 'MyCondition'}]);
+        const tc = new TestContext({ conditions: { MyCondition: true } });
+        const result = runIntrinsic(intrinsics.fnAnd, tc, [true, { Condition: 'MyCondition' }]);
         expect(result).toEqual(ok(true));
     });
 
     test('picks false with inner Condition', async () => {
-        const tc = new TestContext({conditions: {'MyCondition': false}});
-        const result = runIntrinsic(intrinsics.fnAnd, tc, [true, {'Condition': 'MyCondition'}]);
+        const tc = new TestContext({ conditions: { MyCondition: false } });
+        const result = runIntrinsic(intrinsics.fnAnd, tc, [true, { Condition: 'MyCondition' }]);
         expect(result).toEqual(ok(false));
     });
 
@@ -106,10 +108,10 @@ describe('Fn::And', () => {
 
     test('short-cirtcuits evaluation if false is found', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnAnd, tc, [false, {'Condition': 'DoesNotExist'}]);
+        const result = runIntrinsic(intrinsics.fnAnd, tc, [false, { Condition: 'DoesNotExist' }]);
         expect(result).toEqual(ok(false));
     });
-})
+});
 
 describe('Fn::Not', () => {
     test('inverts false', async () => {
@@ -125,14 +127,14 @@ describe('Fn::Not', () => {
     });
 
     test('inverts a false Condition', async () => {
-        const tc = new TestContext({conditions: {'MyCondition': false}});
-        const result = runIntrinsic(intrinsics.fnNot, tc, [{'Condition': 'MyCondition'}]);
+        const tc = new TestContext({ conditions: { MyCondition: false } });
+        const result = runIntrinsic(intrinsics.fnNot, tc, [{ Condition: 'MyCondition' }]);
         expect(result).toEqual(ok(true));
     });
 
     test('inverts a true Condition', async () => {
-        const tc = new TestContext({conditions: {'MyCondition': true}});
-        const result = runIntrinsic(intrinsics.fnNot, tc, [{'Condition': 'MyCondition'}]);
+        const tc = new TestContext({ conditions: { MyCondition: true } });
+        const result = runIntrinsic(intrinsics.fnNot, tc, [{ Condition: 'MyCondition' }]);
         expect(result).toEqual(ok(false));
     });
 
@@ -141,7 +143,7 @@ describe('Fn::Not', () => {
         const result = runIntrinsic(intrinsics.fnNot, tc, ['ok']);
         expect(result).toEqual(failed(`Expected a boolean, got string`));
     });
-})
+});
 
 describe('Fn::Equals', () => {
     test('detects equal strings', async () => {
@@ -158,13 +160,13 @@ describe('Fn::Equals', () => {
 
     test('detects equal objects', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnEquals, tc, [{x: 'a'}, {'x': 'a'}]);
+        const result = runIntrinsic(intrinsics.fnEquals, tc, [{ x: 'a' }, { x: 'a' }]);
         expect(result).toEqual(ok(true));
     });
 
     test('detects unequal objects', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnEquals, tc, [{x: 'a'}, {'x': 'b'}]);
+        const result = runIntrinsic(intrinsics.fnEquals, tc, [{ x: 'a' }, { x: 'b' }]);
         expect(result).toEqual(ok(false));
     });
 
@@ -173,41 +175,47 @@ describe('Fn::Equals', () => {
         const result = runIntrinsic(intrinsics.fnEquals, tc, [1]);
         expect(result).toEqual(failed(`Fn::Equals expects exactly 2 params, got 1`));
     });
-})
+});
 
 describe('Ref', () => {
     test('resolves a parameter by its logical ID', async () => {
-        const tc = new TestContext({parameters: {
-            'MyParam': {id: 'MyParam', Type: 'String', Default: 'MyParamValue'}
-        }});
+        const tc = new TestContext({
+            parameters: {
+                MyParam: { id: 'MyParam', Type: 'String', Default: 'MyParamValue' },
+            },
+        });
         const result = runIntrinsic(intrinsics.ref, tc, ['MyParam']);
         expect(result).toEqual(ok('MyParamValue'));
     });
 
     test('respects "id" resource mapping provided by the user', async () => {
-        const tc = new TestContext({resources: {
-            'MyRes': {
-                resource: <any>{},
-                resourceType: 'AWS::S3::Bucket',
-                attributes: {
-                    'id': 'myID'
+        const tc = new TestContext({
+            resources: {
+                MyRes: {
+                    resource: <any>{},
+                    resourceType: 'AWS::S3::Bucket',
+                    attributes: {
+                        id: 'myID',
+                    },
                 },
             },
-        }});
+        });
         const result = runIntrinsic(intrinsics.ref, tc, ['MyRes']);
         expect(result).toEqual(ok('myID'));
     });
 
     test('resolves a CustomResource to its physical ID', async () => {
-        const tc = new TestContext({resources: {
-            'MyRes': {
-                resource: <any>{
-                    __pulumiType: (<any>aws.cloudformation.CustomResourceEmulator).__pulumiType,
-                    physicalResourceId: 'physicalID',
+        const tc = new TestContext({
+            resources: {
+                MyRes: {
+                    resource: <any>{
+                        __pulumiType: (<any>ccapi.cloudformation.CustomResourceEmulator).__pulumiType,
+                        physicalResourceId: 'physicalID',
+                    },
+                    resourceType: 'AWS::CloudFormation::CustomResource',
                 },
-                resourceType: 'AWS::CloudFormation::CustomResource',
             },
-        }});
+        });
         const result = runIntrinsic(intrinsics.ref, tc, ['MyRes']);
         expect(result).toEqual(ok('physicalID'));
     });
@@ -215,8 +223,10 @@ describe('Ref', () => {
     test('fails if Pulumi metadata indicates Ref is not supported', async () => {
         const tc = new TestContext({
             resources: {
-                'MyRes': {
-                    resource: <any>{},
+                MyRes: {
+                    resource: <any>{
+                        __pulumiType: (<any>ccapi.s3.Bucket).__pulumiType,
+                    },
                     resourceType: 'AWS::S3::Bucket',
                 },
             },
@@ -226,9 +236,9 @@ describe('Ref', () => {
                     outputs: {},
                     cfRef: {
                         notSupported: true,
-                    }
+                    },
                 },
-            }
+            },
         });
         const result = runIntrinsic(intrinsics.ref, tc, ['MyRes']);
         expect(result).toEqual(failed('Ref intrinsic is not supported for the AWS::S3::Bucket resource type'));
@@ -237,8 +247,11 @@ describe('Ref', () => {
     test('resolves to a property value indicated by Pulumi metadata', async () => {
         const tc = new TestContext({
             resources: {
-                'MyRes': {
-                    resource: <any>{stageName: 'my-stage'},
+                MyRes: {
+                    resource: <any>{
+                        stageName: 'my-stage',
+                        __pulumiType: (<any>ccapi.apigateway.Stage).__pulumiType,
+                    },
                     resourceType: 'AWS::ApiGateway::Stage',
                 },
             },
@@ -248,9 +261,34 @@ describe('Ref', () => {
                     outputs: {},
                     cfRef: {
                         property: 'StageName',
-                    }
+                    },
                 },
-            }
+            },
+        });
+        const result = runIntrinsic(intrinsics.ref, tc, ['MyRes']);
+        expect(result).toEqual(ok('my-stage'));
+    });
+
+    test('does not use Pulumi metadata for AWS provider resource', async () => {
+        const tc = new TestContext({
+            resources: {
+                MyRes: {
+                    resource: <any>{
+                        id: 'my-stage',
+                        __pulumiType: (<any>aws.apigateway.Stage).__pulumiType,
+                    },
+                    resourceType: 'AWS::ApiGateway::Stage',
+                },
+            },
+            pulumiMetadata: {
+                'AWS::ApiGateway::Stage': {
+                    inputs: {},
+                    outputs: {},
+                    cfRef: {
+                        property: 'StageName',
+                    },
+                },
+            },
         });
         const result = runIntrinsic(intrinsics.ref, tc, ['MyRes']);
         expect(result).toEqual(ok('my-stage'));
@@ -259,8 +297,12 @@ describe('Ref', () => {
     test('resolves to a join of several property values indicated by Pulumi metadata', async () => {
         const tc = new TestContext({
             resources: {
-                'MyRes': {
-                    resource: <any>{roleName: 'my-role', policyName: 'my-policy'},
+                MyRes: {
+                    resource: <any>{
+                        roleName: 'my-role',
+                        policyName: 'my-policy',
+                        __pulumiType: (<any>ccapi.iam.RolePolicy).__pulumiType,
+                    },
                     resourceType: 'AWS::IAM::RolePolicy',
                 },
             },
@@ -271,9 +313,9 @@ describe('Ref', () => {
                     cfRef: {
                         properties: ['PolicyName', 'RoleName'],
                         delimiter: '|',
-                    }
+                    },
                 },
-            }
+            },
         });
         const result = runIntrinsic(intrinsics.ref, tc, ['MyRes']);
         expect(result).toEqual(ok('my-policy|my-role'));
@@ -282,19 +324,21 @@ describe('Ref', () => {
     test('fails if called with an ID that does not resolve', async () => {
         const tc = new TestContext({});
         const result = runIntrinsic(intrinsics.ref, tc, ['MyParam']);
-        expect(result).toEqual(failed('Ref intrinsic unable to resolve MyParam: not a known logical resource or parameter reference'));
+        expect(result).toEqual(
+            failed('Ref intrinsic unable to resolve MyParam: not a known logical resource or parameter reference'),
+        );
     });
 
     test('evaluates inner expressions before resolving', async () => {
         const tc = new TestContext({
             parameters: {
-                'MyParam': {id: 'MyParam', Type: 'String', Default: 'MyParamValue'}
+                MyParam: { id: 'MyParam', Type: 'String', Default: 'MyParamValue' },
             },
             conditions: {
-                'MyCondition': true,
+                MyCondition: true,
             },
         });
-        const result = runIntrinsic(intrinsics.ref, tc, [{'Fn::If': ['MyCondition', 'MyParam', 'MyParam2']}]);
+        const result = runIntrinsic(intrinsics.ref, tc, [{ 'Fn::If': ['MyCondition', 'MyParam', 'MyParam2'] }]);
         expect(result).toEqual(ok('MyParamValue'));
     });
 
@@ -302,10 +346,10 @@ describe('Ref', () => {
         const stackNodeId = 'stackNodeId';
         const tc = new TestContext({
             parameters: {
-                'MyParam': {id: 'MyParam', Type: 'String', Default: 'MyParamValue'}
+                MyParam: { id: 'MyParam', Type: 'String', Default: 'MyParamValue' },
             },
             conditions: {
-                'MyCondition': true,
+                MyCondition: true,
             },
             accountId: '012345678901',
             region: 'us-west-2',
@@ -320,30 +364,29 @@ describe('Ref', () => {
         expect(runIntrinsic(intrinsics.ref, tc, ['AWS::URLSuffix'])).toEqual(ok('amazonaws.com.cn'));
         expect(runIntrinsic(intrinsics.ref, tc, ['AWS::NoValue'])).toEqual(ok(undefined));
 
-        expect(runIntrinsic(intrinsics.ref, tc, ['AWS::NotificationARNs']))
-            .toEqual(failed('AWS::NotificationARNs pseudo-parameter is not yet supported in pulumi-cdk'));
+        expect(runIntrinsic(intrinsics.ref, tc, ['AWS::NotificationARNs'])).toEqual(
+            failed('AWS::NotificationARNs pseudo-parameter is not yet supported in pulumi-cdk'),
+        );
 
         // These are approximations; testing the current behavior for completeness sake.
         expect(runIntrinsic(intrinsics.ref, tc, ['AWS::StackId'])).toEqual(ok(stackNodeId));
         expect(runIntrinsic(intrinsics.ref, tc, ['AWS::StackName'])).toEqual(ok(stackNodeId));
     });
-})
+});
 
 function runIntrinsic(fn: intrinsics.Intrinsic, tc: TestContext, args: intrinsics.Expression[]): TestResult<any> {
-    const result: TestResult<any> = <any>(fn.evaluate(tc, args));
+    const result: TestResult<any> = <any>fn.evaluate(tc, args);
     return result;
-};
+}
 
-type TestResult<T> =
-    | {'ok': true, value: T}
-    | {'ok': false, errorMessage: string};
+type TestResult<T> = { ok: true; value: T } | { ok: false; errorMessage: string };
 
 function ok<T>(result: T): TestResult<T> {
-    return {'ok': true, value: result};
+    return { ok: true, value: result };
 }
 
 function failed<T>(errorMessage: string): TestResult<T> {
-    return {'ok': false, errorMessage: errorMessage};
+    return { ok: false, errorMessage: errorMessage };
 }
 
 class TestContext implements intrinsics.IntrinsicContext {
@@ -363,10 +406,10 @@ class TestContext implements intrinsics.IntrinsicContext {
         partition?: string;
         urlSuffix?: string;
         stackNodeId?: string;
-        conditions?: { [id: string]: intrinsics.Expression },
-        parameters?: { [id: CloudFormationParameterLogicalId]: CloudFormationParameterWithId },
-        resources?: { [id: string]: Mapping<pulumi.Resource> },
-        pulumiMetadata?: { [cfnType: string]: PulumiResource },
+        conditions?: { [id: string]: intrinsics.Expression };
+        parameters?: { [id: CloudFormationParameterLogicalId]: CloudFormationParameterWithId };
+        resources?: { [id: string]: Mapping<pulumi.Resource> };
+        pulumiMetadata?: { [cfnType: string]: PulumiResource };
     }) {
         this.stackNodeId = args.stackNodeId || '';
         this.accountId = args.accountId || '';
@@ -379,14 +422,18 @@ class TestContext implements intrinsics.IntrinsicContext {
         this.pulumiMetadata = args.pulumiMetadata || {};
     }
 
-    tryFindResource(cfnType: string): PulumiResource|undefined {
-        if (this.pulumiMetadata.hasOwnProperty(cfnType)) {
+    resolveOutput(repr: OutputRepr): pulumi.Output<any> {
+        throw new Error('Method not implemented.');
+    }
+
+    tryFindResource(cfnType: string): PulumiResource | undefined {
+        if (cfnType in this.pulumiMetadata) {
             return this.pulumiMetadata[cfnType];
         }
-    };
+    }
 
     findParameter(parameterLogicalID: string): CloudFormationParameterWithId | undefined {
-        if (this.parameters.hasOwnProperty(parameterLogicalID)) {
+        if (parameterLogicalID in this.parameters) {
             return this.parameters[parameterLogicalID];
         }
     }
@@ -396,37 +443,39 @@ class TestContext implements intrinsics.IntrinsicContext {
         return this.succeed(param.Default!);
     }
 
-    findCondition(conditionName: string): intrinsics.Expression|undefined {
-        if (this.conditions.hasOwnProperty(conditionName)) {
+    findCondition(conditionName: string): intrinsics.Expression | undefined {
+        if (conditionName in this.conditions) {
             return this.conditions[conditionName];
         }
     }
 
     findResourceMapping(resourceLogicalID: string): Mapping<pulumi.Resource> | undefined {
-        if (this.resources.hasOwnProperty(resourceLogicalID)) {
+        if (resourceLogicalID in this.resources) {
             return this.resources[resourceLogicalID];
         }
     }
 
     evaluate(expression: intrinsics.Expression): intrinsics.Result<any> {
         // Evaluate known heuristics.
-        const known = [intrinsics.fnAnd,
-                       intrinsics.fnEquals,
-                       intrinsics.fnIf,
-                       intrinsics.fnNot,
-                       intrinsics.fnOr,
-                       intrinsics.ref];
+        const known = [
+            intrinsics.fnAnd,
+            intrinsics.fnEquals,
+            intrinsics.fnIf,
+            intrinsics.fnNot,
+            intrinsics.fnOr,
+            intrinsics.ref,
+        ];
         if (typeof expression === 'object' && Object.keys(expression).length == 1) {
             for (const k of known) {
                 if (k.name === Object.keys(expression)[0]) {
                     const args = expression[k.name];
-                    return k.evaluate(this, args)
+                    return k.evaluate(this, args);
                 }
             }
         }
 
         // Self-evaluate the expression. This is very incomplete.
-        const result: TestResult<any> = {'ok': true, value: expression};
+        const result: TestResult<any> = { ok: true, value: expression };
         return result;
     }
 
@@ -435,17 +484,17 @@ class TestContext implements intrinsics.IntrinsicContext {
         if (t.ok) {
             return fn(t.value);
         } else {
-            return {'ok': false, errorMessage: t.errorMessage};
+            return { ok: false, errorMessage: t.errorMessage };
         }
     }
 
     fail(msg: string): intrinsics.Result<any> {
-        const result: TestResult<any> = {'ok': false, errorMessage: msg};
+        const result: TestResult<any> = { ok: false, errorMessage: msg };
         return result;
     }
 
     succeed<T>(r: T): intrinsics.Result<T> {
-        const result: TestResult<any> = {'ok': true, value: r};
+        const result: TestResult<any> = { ok: true, value: r };
         return result;
     }
 


### PR DESCRIPTION
We use the `Ref` metadata to determine which attribute the `Ref` intrinsic should reference. This metadata is only valid for CCAPI resources though so we need to exclude any other resource type.

This PR checks the internal `__pulumiType` to determine if the resource is an `aws-native` resource. I chose to do it this way because we need to check the resource itself, we can't rely on any other information source. For example, the user could provide their own mapping function that maps some resources to `aws-native` and some resources to `aws`.

closes #262