### PR TITLE
Add a postUpgradeTask to bump metadata for aws-native

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Used as a postUpgradeTask by Renovate. See ./renovate.json5.
 .PHONY: renovate
 renovate:
-	VERSION=$(shell cat package.json | jq -r '.devDependencies["@pulumi/aws-native"]' | sed 's/^\^/v/'); \
-	curl -L https://raw.githubusercontent.com/pulumi/pulumi-aws-native/refs/tags/$${VERSION}/provider/cmd/pulumi-resource-aws-native/metadata.json -o schemas/aws-native-metadata.json
+	VERSION=$(shell cat package.json | jq -r '.devDependencies["@pulumi/aws-native"]'); \
+	curl -L https://raw.githubusercontent.com/pulumi/pulumi-aws-native/refs/tags/v$${VERSION}/provider/cmd/pulumi-resource-aws-native/metadata.json -o schemas/aws-native-metadata.json
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+# Used as a postUpgradeTask by Renovate. See ./renovate.json5.
+.PHONY: renovate
+renovate:
+	VERSION=$(shell cat package.json | jq -r '.devDependencies["@pulumi/aws-native"]' | sed 's/^\^/v/'); \
+	curl -L https://raw.githubusercontent.com/pulumi/pulumi-aws-native/refs/tags/$${VERSION}/provider/cmd/pulumi-resource-aws-native/metadata.json -o schemas/aws-native-metadata.json
+

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,15 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["github>pulumi/renovate-config//default.json5"],
+  packageRules: [
+    {
+      // Update metadata when aws-native is bumped.
+      matchDatasources: ["npm"],
+      matchPackageNames: ["@pulumi/aws-native"],
+      postUpgradeTasks: {
+        commands: ["make renovate"],
+        executionMode: "branch", // Only run once. 
+      },
+    },
+  ]
+}

--- a/scripts/update-aws-native.sh
+++ b/scripts/update-aws-native.sh
@@ -21,7 +21,7 @@ echo "Updating ./package.json"
 npx ncu --filter @pulumi/aws-native --upgrade
 yarn install
 
-VERSION=$(cat package.json | jq -r '.devDependencies["@pulumi/aws-native"]' | sed 's/^\^/v/')
+VERSION=$(cat package.json | jq -r '.devDependencies["@pulumi/aws-native"]')
 
 echo "Updating metadata.json"
-curl -L  https://raw.githubusercontent.com/pulumi/pulumi-aws-native/refs/tags/$VERSION/provider/cmd/pulumi-resource-aws-native/metadata.json -o schemas/aws-native-metadata.json
+curl -L  https://raw.githubusercontent.com/pulumi/pulumi-aws-native/refs/tags/v$VERSION/provider/cmd/pulumi-resource-aws-native/metadata.json -o schemas/aws-native-metadata.json


### PR DESCRIPTION
This adds a [postUpgradeTask](https://github.com/pulumi/renovate-config?tab=readme-ov-file#post-upgrade-tasks) to update metadata whenever `@pulumi/aws-native` is bumped. 

The metadata bump is straightforward enough that we should be able to run it inside Renovate without trouble.

This is defined as a make target because Renovate requires post-run tasks to be explicitly allowed, and for the moment we allow `make renovate` for simplicity. We can think about expanding allowable commands in the future.