### PR TITLE
Fix BucketObjectv2 should only trigger an update on code changes

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -90,7 +90,15 @@ func TestFargate(t *testing.T) {
 func TestS3ObjectLambda(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir: filepath.Join(getCwd(t), "s3-object-lambda"),
+			Dir:                  filepath.Join(getCwd(t), "s3-object-lambda"),
+			ExpectRefreshChanges: false,
+			EditDirs: []integration.EditDir{
+				{
+					Dir:             filepath.Join(getCwd(t), "s3-object-lambda"),
+					ExpectNoChanges: true,
+					Additive:        true,
+				},
+			},
 		})
 
 	integration.ProgramTest(t, &test)

--- a/src/synthesizer.ts
+++ b/src/synthesizer.ts
@@ -502,10 +502,12 @@ export class PulumiSynthesizer extends PulumiSynthesizerBase implements cdk.IReu
                 ? zipDirectory(assetFile, assetFile + '.zip')
                 : assetFile;
 
+        const fileAsset = new pulumi.asset.FileAsset(outputPath);
+
         const object = new aws.s3.BucketObjectv2(
             `${this.stagingStack.name}/${asset.sourceHash}`,
             {
-                source: outputPath,
+                source: fileAsset,
                 bucket: stagingBucket.bucket,
                 key: location.objectKey,
             },


### PR DESCRIPTION
This fixes the issue by switching to use Pulumi assets instead of the filepath directly. The filepath includes the random `cdk.out` directory so it will always be different. Assets handle this case.

fixes #73