### PR TITLE
chore: add additional directories to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,6 @@
 /examples/
+/integration/
+/scripts/
 /tests/
 /src/
 /coverage/


### PR DESCRIPTION
We don't need to publish these as part of the npm artifact.