### PR TITLE
Enhance CDK support with nested stack handling

### DIFF
--- a/src/assembly/types.ts
+++ b/src/assembly/types.ts
@@ -6,7 +6,16 @@ export type StackAsset = FileManifestEntry | DockerImageManifestEntry;
 /**
  * Map of CDK construct path to logicalId
  */
-export type StackMetadata = { [path: string]: string };
+export type StackMetadata = { [path: string]: StackAddress };
+
+/**
+ * StackAddress uniquely identifies a resource in a cloud assembly
+ * across several (nested) stacks.
+ */
+export type StackAddress = {
+    id: string;
+    stackPath: string;
+};
 
 /**
  * ConstructTree is a tree of the current CDK construct

--- a/src/cfn.ts
+++ b/src/cfn.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import { CfnDeletionPolicy } from 'aws-cdk-lib/core';
+import { StackAddress } from './assembly';
 
 /**
  * Represents a CF parameter declaration from the Parameters template section.
@@ -28,10 +29,8 @@ export interface CloudFormationParameter {
     readonly Default?: any;
 }
 
-export type CloudFormationParameterLogicalId = string;
-
 export interface CloudFormationParameterWithId extends CloudFormationParameter {
-    id: CloudFormationParameterLogicalId;
+    stackAddress: StackAddress;
 }
 
 export interface CloudFormationResource {
@@ -40,6 +39,11 @@ export interface CloudFormationResource {
     readonly Condition?: string;
     readonly DeletionPolicy?: CfnDeletionPolicy;
     readonly DependsOn?: string | string[];
+    readonly Metadata?: { [key: string]: any };
+}
+
+export interface CloudFormationOutput {
+    Value: any;
 }
 
 export type CloudFormationMapping = { [mappingLogicalName: string]: TopLevelMapping };
@@ -63,7 +67,18 @@ export interface CloudFormationTemplate {
     Resources?: { [id: string]: CloudFormationResource };
     Conditions?: { [id: string]: CloudFormationCondition };
     Mappings?: CloudFormationMapping;
-    Outputs?: { [id: string]: any };
+    Outputs?: { [id: string]: CloudFormationOutput };
+}
+
+export interface NestedStackTemplate extends CloudFormationTemplate {
+    /**
+     * The logical ID identifying the nested stack in the parent stack.
+     */
+    logicalId: string;
+}
+
+export function isNestedStackTemplate(template: CloudFormationTemplate): template is NestedStackTemplate {
+    return 'logicalId' in template;
 }
 
 export function getDependsOn(resource: CloudFormationResource): string[] | undefined {

--- a/src/converters/app-converter.ts
+++ b/src/converters/app-converter.ts
@@ -458,18 +458,23 @@ export class StackConverter extends ArtifactConverter implements intrinsics.Intr
             for (const [stackPath, _] of this.graph.nestedStackNodes) {
                 if (stackPath === this.stack.constructTree.path) continue;
 
+                let result;
                 try {
-                    const result = this.processIntrinsics(value, stackPath);
-                    if (foundValue !== null) {
-                        throw new CdkAdapterError(
-                            `Value found in multiple stacks: ${foundStack} and ${stackPath}. Pulumi cannot resolve this value.`,
-                        );
-                    }
-                    foundValue = result;
-                    foundStack = stackPath;
+                    result = this.processIntrinsics(value, stackPath);
                 } catch {
                     // Continue searching other stacks
+                    continue;
                 }
+                if (!result) {
+                    continue;
+                }
+                if (foundValue !== null) {
+                    throw new CdkAdapterError(
+                        `Value found in multiple stacks: ${foundStack} and ${stackPath}. Pulumi cannot resolve this value.`,
+                    );
+                }
+                foundValue = result;
+                foundStack = stackPath;
             }
 
             if (foundValue !== null) {

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -567,15 +567,11 @@ export class GraphBuilder {
                 stackPath,
             });
             if (targetNode === undefined) {
-                // If this is a nested stack, we need to check if the parameter is set by the parent stack and add an edge for the stack resource in the parent stack
+                // If this is a nested stack, we need to check if the parameter is set by the parent stack
                 if (!this.stack.isRootStack(stackPath)) {
                     const nestedStackNode = this.nestedStackNodes.get(stackPath);
                     if (nestedStackNode?.resource?.Properties?.Parameters?.[targetLogicalId]) {
-                        debug(
-                            `Parameter ${targetLogicalId} is set by the parent stack, adding edge from ${source.construct.path} to ${nestedStackNode.construct.path}`,
-                        );
-                        source.outgoingEdges.add(nestedStackNode);
-                        nestedStackNode.incomingEdges.add(source);
+                        debug(`Parameter ${targetLogicalId} is set by the parent stack ${stackPath}`);
                         return;
                     }
                 }

--- a/src/interop.ts
+++ b/src/interop.ts
@@ -124,3 +124,28 @@ export class CdkConstruct extends pulumi.ComponentResource {
         this.registerOutputs({});
     }
 }
+
+const NESTED_STACK_CONSTRUCT_SYMBOL = Symbol.for('@pulumi/cdk.NestedStackConstruct');
+
+/**
+ * The NestedStackConstruct is a special construct that is used to represent a nested stack
+ * and namespace the resources within it. It achieves this by including the stack path in the
+ * resource type.
+ * @internal
+ */
+export class NestedStackConstruct extends pulumi.ComponentResource {
+    /**
+     * Return whether the given object is a NestedStackConstruct.
+     *
+     * We do attribute detection in order to reliably detect nested stack constructs.
+     * @internal
+     */
+    public static isNestedStackConstruct(x: any): x is NestedStackConstruct {
+        return x !== null && typeof x === 'object' && NESTED_STACK_CONSTRUCT_SYMBOL in x;
+    }
+
+    constructor(stackPath: string, options?: pulumi.ComponentResourceOptions) {
+        super(`cdk:construct:nested-stack/${stackPath}`, stackPath, {}, options);
+        Object.defineProperty(this, NESTED_STACK_CONSTRUCT_SYMBOL, { value: true });
+    }
+}

--- a/src/stack-map.ts
+++ b/src/stack-map.ts
@@ -1,0 +1,166 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { StackAddress } from './assembly';
+
+/**
+ * A specialized Map implementation that uses StackAddress objects as keys.
+ * It internally uses nested maps to store values by stackPath and id.
+ *
+ * @typeparam T The type of values stored in the map
+ *
+ * @internal
+ */
+export class StackMap<T> implements Map<StackAddress, T> {
+    // Map of stackPath -> Map of id -> value
+    private _map: Map<string, Map<string, T>> = new Map();
+
+    /**
+     * Removes all elements from the map
+     */
+    clear(): void {
+        this._map.clear();
+    }
+
+    /**
+     * Removes the specified element from the map
+     * @param key The StackAddress key to remove
+     * @returns true if an element was removed, false otherwise
+     */
+    delete(key: StackAddress): boolean {
+        const { stackPath, id: id } = key;
+        const innerMap = this._map.get(stackPath);
+        if (!innerMap) {
+            return false;
+        }
+        return innerMap.delete(id);
+    }
+
+    /**
+     * Returns the value associated with the specified key
+     * @param key The StackAddress key to look up
+     * @returns The value associated with the key, or undefined if not found
+     */
+    get(key: StackAddress): T | undefined {
+        const { stackPath, id: id } = key;
+        return this._map.get(stackPath)?.get(id);
+    }
+
+    /**
+     * Returns whether an element with the specified key exists
+     * @param key The StackAddress key to check
+     * @returns true if the key exists, false otherwise
+     */
+    has(key: StackAddress): boolean {
+        const { stackPath, id: id } = key;
+        return !!this._map.get(stackPath)?.has(id);
+    }
+
+    /**
+     * Adds or updates an element with the specified key and value
+     * @param key The StackAddress key to set
+     * @param value The value to associate with the key
+     * @returns The StackMap object
+     */
+    set(key: StackAddress, value: T): this {
+        const { stackPath, id: id } = key;
+        let innerMap = this._map.get(stackPath);
+        if (!innerMap) {
+            innerMap = new Map();
+            this._map.set(stackPath, innerMap);
+        }
+        innerMap.set(id, value);
+        return this;
+    }
+
+    /**
+     * Returns the number of elements in the map
+     */
+    public get size(): number {
+        return Array.from(this._map.values()).reduce((acc: number, innerMap) => acc + innerMap.size, 0);
+    }
+
+    /**
+     * Executes a provided function once for each key-value pair in the map
+     * @param callbackfn Function to execute for each element
+     * @param thisArg Value to use as 'this' when executing callback
+     */
+    forEach(callbackfn: (value: T, key: StackAddress, map: Map<StackAddress, T>) => void, thisArg?: any): void {
+        for (const [stackPath, innerMap] of this._map) {
+            for (const [id, value] of innerMap) {
+                const key = { stackPath, id };
+                callbackfn.call(thisArg, value, key, this as any);
+            }
+        }
+    }
+
+    forEachStackElement(
+        stackPath: string,
+        callbackfn: (value: T, key: StackAddress, map: Map<StackAddress, T>) => void,
+        thisArg?: any,
+    ): void {
+        const innerMap = this._map.get(stackPath);
+        if (!innerMap) {
+            return;
+        }
+        for (const [id, value] of innerMap) {
+            const key = { stackPath, id };
+            callbackfn.call(thisArg, value, key, this as any);
+        }
+    }
+
+    /**
+     * Returns an iterator of key-value pairs for every entry in the map
+     * @returns An iterator yielding [StackAddress, T] pairs
+     */
+    *entries(): IterableIterator<[StackAddress, T]> {
+        for (const [stackPath, innerMap] of this._map) {
+            for (const [id, value] of innerMap) {
+                yield [{ stackPath, id: id }, value];
+            }
+        }
+    }
+
+    /**
+     * Returns an iterator of keys in the map
+     * @returns An iterator yielding StackAddress keys
+     */
+    *keys(): IterableIterator<StackAddress> {
+        for (const [stackPath, innerMap] of this._map) {
+            for (const id of innerMap.keys()) {
+                yield { stackPath, id: id };
+            }
+        }
+    }
+
+    /**
+     * Returns an iterator of values in the map
+     * @returns An iterator yielding the values
+     */
+    *values(): IterableIterator<T> {
+        for (const innerMap of this._map.values()) {
+            yield* innerMap.values();
+        }
+    }
+
+    /**
+     * Returns the default iterator for the map
+     * @returns An iterator for entries in the map
+     */
+    [Symbol.iterator](): IterableIterator<[StackAddress, T]> {
+        return this.entries();
+    }
+
+    [Symbol.toStringTag] = 'StackMap';
+}

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -124,8 +124,8 @@ export class App
             return stacks.reduce(
                 (prev, curr) => {
                     const o: { [outputId: string]: pulumi.Output<any> } = {};
-                    for (const [outputId, args] of Object.entries(curr.stack.outputs ?? {})) {
-                        o[outputId] = curr.processIntrinsics(args.Value);
+                    for (const [outputId, args] of Object.entries(curr.stack.getRootStack().Outputs ?? {})) {
+                        o[outputId] = curr.processIntrinsics(args.Value, curr.stack.id);
                     }
                     return {
                         ...prev,

--- a/tests/assembly/manifest.test.ts
+++ b/tests/assembly/manifest.test.ts
@@ -3,157 +3,296 @@ import * as mockfs from 'mock-fs';
 import { AssemblyManifestReader } from '../../src/assembly';
 
 describe('cloud assembly manifest reader', () => {
-    const manifestFile = '/tmp/foo/bar/does/not/exist/manifest.json';
-    const manifestStack = '/tmp/foo/bar/does/not/exist/test-stack.template.json';
-    const manifestTree = '/tmp/foo/bar/does/not/exist/tree.json';
-    const manifestAssets = '/tmp/foo/bar/does/not/exist/test-stack.assets.json';
-    beforeEach(() => {
-        mockfs({
-            // Recursively loads all node_modules
-            node_modules: {
-                'aws-cdk-lib': mockfs.load(path.resolve(__dirname, '../../node_modules/aws-cdk-lib')),
-                '@pulumi': {
-                    aws: mockfs.load(path.resolve(__dirname, '../../node_modules/@pulumi/aws')),
-                    'aws-native': mockfs.load(path.resolve(__dirname, '../../node_modules/@pulumi/aws-native')),
+    describe('single stack', () => {
+        const manifestFile = '/tmp/foo/bar/does/not/exist/manifest.json';
+        const manifestStack = '/tmp/foo/bar/does/not/exist/test-stack.template.json';
+        const manifestTree = '/tmp/foo/bar/does/not/exist/tree.json';
+        const manifestAssets = '/tmp/foo/bar/does/not/exist/test-stack.assets.json';
+        beforeEach(() => {
+            mockfs({
+                // Recursively loads all node_modules
+                node_modules: {
+                    'aws-cdk-lib': mockfs.load(path.resolve(__dirname, '../../node_modules/aws-cdk-lib')),
+                    '@pulumi': {
+                        aws: mockfs.load(path.resolve(__dirname, '../../node_modules/@pulumi/aws')),
+                        'aws-native': mockfs.load(path.resolve(__dirname, '../../node_modules/@pulumi/aws-native')),
+                    },
                 },
-            },
-            [manifestAssets]: JSON.stringify({
-                version: '36.0.0',
-                files: {
-                    abe4e2f4fcc1aaaf53db4829c23a5cf08795d36cce0f68a3321c1c8d728fec44: {
-                        source: {
-                            path: 'asset.abe4e2f4fcc1aaaf53db4829c23a5cf08795d36cce0f68a3321c1c8d728fec44',
-                            packaging: 'zip',
+                [manifestAssets]: JSON.stringify({
+                    version: '36.0.0',
+                    files: {
+                        abe4e2f4fcc1aaaf53db4829c23a5cf08795d36cce0f68a3321c1c8d728fec44: {
+                            source: {
+                                path: 'asset.abe4e2f4fcc1aaaf53db4829c23a5cf08795d36cce0f68a3321c1c8d728fec44',
+                                packaging: 'zip',
+                            },
+                            destinations: {
+                                'current_account-current_region': {
+                                    bucketName: 'cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}',
+                                    objectKey: 'abe4e2f4fcc1aaaf53db4829c23a5cf08795d36cce0f68a3321c1c8d728fec44.zip',
+                                },
+                            },
                         },
-                        destinations: {
-                            'current_account-current_region': {
-                                bucketName: 'cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}',
-                                objectKey: 'abe4e2f4fcc1aaaf53db4829c23a5cf08795d36cce0f68a3321c1c8d728fec44.zip',
+                        cd12352cc95113284dfa6575f1d74d8dea52dddcaa2f46fa695b33b59c1b4579: {
+                            source: {
+                                path: 'stack.template.json',
+                                packaging: 'file',
+                            },
+                            destinations: {
+                                'current_account-current_region': {
+                                    bucketName: 'cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}',
+                                    objectKey: 'cd12352cc95113284dfa6575f1d74d8dea52dddcaa2f46fa695b33b59c1b4579.json',
+                                },
                             },
                         },
                     },
-                    cd12352cc95113284dfa6575f1d74d8dea52dddcaa2f46fa695b33b59c1b4579: {
-                        source: {
-                            path: 'stack.template.json',
-                            packaging: 'file',
-                        },
-                        destinations: {
-                            'current_account-current_region': {
-                                bucketName: 'cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}',
-                                objectKey: 'cd12352cc95113284dfa6575f1d74d8dea52dddcaa2f46fa695b33b59c1b4579.json',
+                    dockerImages: {},
+                }),
+                [manifestTree]: JSON.stringify({
+                    version: 'tree-0.1',
+                    tree: {
+                        id: 'App',
+                        path: '',
+                        children: {
+                            'test-stack': {
+                                id: 'test-stack',
+                                path: 'test-stack',
                             },
                         },
                     },
-                },
-                dockerImages: {},
-            }),
-            [manifestTree]: JSON.stringify({
-                version: 'tree-0.1',
-                tree: {
-                    id: 'App',
-                    path: '',
-                    children: {
+                }),
+                [manifestStack]: JSON.stringify({
+                    Resources: {
+                        MyFunction1ServiceRole9852B06B: {
+                            Type: 'AWS::IAM::Role',
+                            Properties: {},
+                        },
+                        MyFunction12A744C2E: {
+                            Type: 'AWS::Lambda::Function',
+                            Properties: {},
+                        },
+                    },
+                }),
+                [manifestFile]: JSON.stringify({
+                    version: '17.0.0',
+                    artifacts: {
+                        'test-stack.assets': {
+                            type: 'cdk:asset-manifest',
+                            properties: {
+                                file: 'test-stack.assets.json',
+                            },
+                        },
+                        Tree: {
+                            type: 'cdk:tree',
+                            properties: {
+                                file: 'tree.json',
+                            },
+                        },
                         'test-stack': {
-                            id: 'test-stack',
-                            path: 'test-stack',
+                            type: 'aws:cloudformation:stack',
+                            environment: 'aws://unknown-account/unknown-region',
+                            properties: {
+                                templateFile: 'test-stack.template.json',
+                                validateOnSynth: false,
+                            },
+                            metadata: {
+                                '/test-stack/MyFunction1/ServiceRole/Resource': [
+                                    {
+                                        type: 'aws:cdk:logicalId',
+                                        data: 'MyFunction1ServiceRole9852B06B',
+                                    },
+                                ],
+                                '/test-stack/MyFunction1/Resource': [
+                                    {
+                                        type: 'aws:cdk:logicalId',
+                                        data: 'MyFunction12A744C2E',
+                                    },
+                                ],
+                            },
+                            displayName: 'test-stack',
                         },
                     },
+                }),
+            });
+        });
+    
+        afterEach(() => {
+            mockfs.restore();
+        });
+    
+        test('throws if manifest file not found', () => {
+            expect(() => {
+                AssemblyManifestReader.fromDirectory('some-other-file');
+            }).toThrow(/Cannot read manifest at 'some-other-file\/manifest.json'/);
+        });
+    
+        test('can read manifest from path', () => {
+            expect(() => {
+                AssemblyManifestReader.fromDirectory(path.dirname(manifestFile));
+            }).not.toThrow();
+        });
+    
+        test('fromPath sets directory correctly', () => {
+            const manifest = AssemblyManifestReader.fromDirectory(path.dirname(manifestFile));
+            expect(manifest.directory).toEqual('/tmp/foo/bar/does/not/exist');
+        });
+    
+        test('can get stacks from manifest', () => {
+            const manifest = AssemblyManifestReader.fromDirectory(path.dirname(manifestFile));
+    
+            expect(manifest.stackManifests[0]).toEqual({
+                constructTree: { id: 'test-stack', path: 'test-stack' },
+                dependencies: [],
+                id: 'test-stack',
+                metadata: {
+                    'test-stack/MyFunction1/Resource': { stackPath: 'test-stack', id: 'MyFunction12A744C2E' },
+                    'test-stack/MyFunction1/ServiceRole/Resource': { stackPath: 'test-stack', id: 'MyFunction1ServiceRole9852B06B' },
                 },
-            }),
-            [manifestStack]: JSON.stringify({
-                Resources: {
-                    MyFunction1ServiceRole9852B06B: {
-                        Type: 'AWS::IAM::Role',
-                        Properties: {},
-                    },
-                    MyFunction12A744C2E: {
-                        Type: 'AWS::Lambda::Function',
-                        Properties: {},
-                    },
+                stacks: {
+                    "test-stack": {
+                        Resources: {
+                            MyFunction12A744C2E: { Properties: {}, Type: 'AWS::Lambda::Function' },
+                            MyFunction1ServiceRole9852B06B: { Properties: {}, Type: 'AWS::IAM::Role' },
+                        },
+                    }
                 },
-            }),
-            [manifestFile]: JSON.stringify({
-                version: '17.0.0',
-                artifacts: {
-                    'test-stack.assets': {
-                        type: 'cdk:asset-manifest',
-                        properties: {
-                            file: 'test-stack.assets.json',
-                        },
-                    },
-                    Tree: {
-                        type: 'cdk:tree',
-                        properties: {
-                            file: 'tree.json',
-                        },
-                    },
-                    'test-stack': {
-                        type: 'aws:cloudformation:stack',
-                        environment: 'aws://unknown-account/unknown-region',
-                        properties: {
-                            templateFile: 'test-stack.template.json',
-                            validateOnSynth: false,
-                        },
-                        metadata: {
-                            '/test-stack/MyFunction1/ServiceRole/Resource': [
-                                {
-                                    type: 'aws:cdk:logicalId',
-                                    data: 'MyFunction1ServiceRole9852B06B',
-                                },
-                            ],
-                            '/test-stack/MyFunction1/Resource': [
-                                {
-                                    type: 'aws:cdk:logicalId',
-                                    data: 'MyFunction12A744C2E',
-                                },
-                            ],
-                        },
-                        displayName: 'test-stack',
-                    },
-                },
-            }),
+                templatePath: 'test-stack.template.json',
+            });
         });
     });
 
-    afterEach(() => {
-        mockfs.restore();
-    });
+    describe('nested stacks', () => {
+        afterEach(() => {
+            mockfs.restore();
+        });
 
-    test('throws if manifest file not found', () => {
-        expect(() => {
-            AssemblyManifestReader.fromDirectory('some-other-file');
-        }).toThrow(/Cannot read manifest at 'some-other-file\/manifest.json'/);
-    });
+        test('can read manifest with nested stacks', () => {
+            const manifestDir = path.join(__dirname, '../test-data/nested-stack');
+            const manifests = AssemblyManifestReader.fromDirectory(manifestDir).stackManifests;
+            expect(manifests.length).toEqual(1);
+            const manifest = manifests[0];
+            expect(Object.keys(manifest.stacks)).toEqual(['teststack', 'teststack/nesty']);
+            expect(Object.keys(manifest.stacks['teststack'].Resources ?? {}).length).toEqual(7);
+            expect(Object.keys(manifest.stacks['teststack/nesty'].Resources ?? {}).length).toEqual(5);
+        });
 
-    test('can read manifest from path', () => {
-        expect(() => {
-            AssemblyManifestReader.fromDirectory(path.dirname(manifestFile));
-        }).not.toThrow();
-    });
+        test('throws if nested stack template is not found', () => {
+            const manifestFile = '/tmp/foo/bar/does/not/exist/manifest.json';
+            const manifestStack = '/tmp/foo/bar/does/not/exist/test-stack.template.json';
+            const manifestTree = '/tmp/foo/bar/does/not/exist/tree.json';
+            const manifestAssets = '/tmp/foo/bar/does/not/exist/test-stack.assets.json';
+            mockfs({
+                [manifestAssets]: JSON.stringify({
+                    version: '36.0.0',
+                    files: {
+                        abe4e2f4fcc1aaaf53db4829c23a5cf08795d36cce0f68a3321c1c8d728fec44: {
+                            source: {
+                                path: 'asset.abe4e2f4fcc1aaaf53db4829c23a5cf08795d36cce0f68a3321c1c8d728fec44',
+                                packaging: 'zip',
+                            },
+                            destinations: {
+                                'current_account-current_region': {
+                                    bucketName: 'cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}',
+                                    objectKey: 'abe4e2f4fcc1aaaf53db4829c23a5cf08795d36cce0f68a3321c1c8d728fec44.zip',
+                                },
+                            },
+                        },
+                        cd12352cc95113284dfa6575f1d74d8dea52dddcaa2f46fa695b33b59c1b4579: {
+                            source: {
+                                path: 'stack.template.json',
+                                packaging: 'file',
+                            },
+                            destinations: {
+                                'current_account-current_region': {
+                                    bucketName: 'cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}',
+                                    objectKey: 'cd12352cc95113284dfa6575f1d74d8dea52dddcaa2f46fa695b33b59c1b4579.json',
+                                },
+                            },
+                        },
+                    },
+                    dockerImages: {},
+                }),
+                [manifestTree]: JSON.stringify({
+                    version: 'tree-0.1',
+                    tree: {
+                        id: 'App',
+                        path: '',
+                        children: {
+                            'test-stack': {
+                                id: 'test-stack',
+                                path: 'test-stack',
+                                children: {
+                                    'MyNestedStack': {
+                                        id: 'MyNestedStack',
+                                        path: 'test-stack/MyNestedStack',
+                                    },
+                                    'MyNestedStack.NestedStack': {
+                                        id: 'MyNestedStack.NestedStack',
+                                        path: 'test-stack/MyNestedStack.NestedStack',
+                                        children: {
+                                            'MyNestedStack.NestedStackResource': {
+                                                id: 'MyNestedStack.NestedStackResource',
+                                                path: 'test-stack/MyNestedStack.NestedStack/MyNestedStack.NestedStackResource',
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                }),
+                [manifestStack]: JSON.stringify({
+                    Resources: {
+                        MyNestedStack: {
+                            Type: 'AWS::CloudFormation::Stack',
+                            Properties: {},
+                            Metadata: {
+                                // this asset path does not exist
+                                'aws:asset:path': 'MyNestedStack.template.json',
+                                'aws:cdk:path': 'test-stack/MyNestedStack.NestedStack/MyNestedStack.NestedStackResource',
+                            },
+                        },
+                    },
+                }),
+                [manifestFile]: JSON.stringify({
+                    version: '17.0.0',
+                    artifacts: {
+                        'test-stack.assets': {
+                            type: 'cdk:asset-manifest',
+                            properties: {
+                                file: 'test-stack.assets.json',
+                            },
+                        },
+                        Tree: {
+                            type: 'cdk:tree',
+                            properties: {
+                                file: 'tree.json',
+                            },
+                        },
+                        'test-stack': {
+                            type: 'aws:cloudformation:stack',
+                            environment: 'aws://unknown-account/unknown-region',
+                            properties: {
+                                templateFile: 'test-stack.template.json',
+                                validateOnSynth: false,
+                            },
+                            metadata: {
+                                '/test-stack/MyNestedStack.NestedStack/MyNestedStack.NestedStackResource': [
+                                    {
+                                        type: 'aws:cdk:logicalId',
+                                        data: 'MyNestedStack',
+                                    },
+                                ],
+                            },
+                            displayName: 'test-stack',
+                        },
+                    },
+                }),
+            });
 
-    test('fromPath sets directory correctly', () => {
-        const manifest = AssemblyManifestReader.fromDirectory(path.dirname(manifestFile));
-        expect(manifest.directory).toEqual('/tmp/foo/bar/does/not/exist');
-    });
-
-    test('can get stacks from manifest', () => {
-        const manifest = AssemblyManifestReader.fromDirectory(path.dirname(manifestFile));
-
-        expect(manifest.stackManifests[0]).toEqual({
-            constructTree: { id: 'test-stack', path: 'test-stack' },
-            dependencies: [],
-            id: 'test-stack',
-            metadata: {
-                'test-stack/MyFunction1/Resource': 'MyFunction12A744C2E',
-                'test-stack/MyFunction1/ServiceRole/Resource': 'MyFunction1ServiceRole9852B06B',
-            },
-            outputs: undefined,
-            parameters: undefined,
-            resources: {
-                MyFunction12A744C2E: { Properties: {}, Type: 'AWS::Lambda::Function' },
-                MyFunction1ServiceRole9852B06B: { Properties: {}, Type: 'AWS::IAM::Role' },
-            },
-            templatePath: 'test-stack.template.json',
+            expect(() => {
+                AssemblyManifestReader.fromDirectory(path.dirname(manifestFile));
+            }).toThrow(/no such file or directory, open '\/tmp\/foo\/bar\/does\/not\/exist\/MyNestedStack.template.json'/);
         });
     });
 });

--- a/tests/converters/intrinsics.test.ts
+++ b/tests/converters/intrinsics.test.ts
@@ -4,35 +4,35 @@ import * as pulumi from '@pulumi/pulumi';
 import * as intrinsics from '../../src/converters/intrinsics';
 import {
     CloudFormationParameter,
-    CloudFormationParameterLogicalId,
     CloudFormationParameterWithId,
 } from '../../src/cfn';
 import { Mapping } from '../../src/types';
 import { PulumiResource } from '../../src/pulumi-metadata';
 import { OutputRepr } from '../../src/output-map';
+import { StackAddress } from '../../src/assembly';
 
 describe('Fn::If', () => {
     test('picks true', async () => {
-        const tc = new TestContext({ conditions: { MyCondition: true } });
-        const result = runIntrinsic(intrinsics.fnIf, tc, ['MyCondition', 'yes', 'no']);
+        const tc = new TestContext({ conditions: { 'test-stack': { MyCondition: true }} });
+        const result = runIntrinsic(intrinsics.fnIf, tc, ['MyCondition', 'yes', 'no'], 'test-stack');
         expect(result).toEqual(ok('yes'));
     });
 
     test('picks false', async () => {
-        const tc = new TestContext({ conditions: { MyCondition: false } });
-        const result = runIntrinsic(intrinsics.fnIf, tc, ['MyCondition', 'yes', 'no']);
+        const tc = new TestContext({ conditions: { 'test-stack': { MyCondition: false } } });
+        const result = runIntrinsic(intrinsics.fnIf, tc, ['MyCondition', 'yes', 'no'], 'test-stack');
         expect(result).toEqual(ok('no'));
     });
 
     test('errors if condition is not found', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnIf, tc, ['MyCondition', 'yes', 'no']);
+        const result = runIntrinsic(intrinsics.fnIf, tc, ['MyCondition', 'yes', 'no'], 'test-stack');
         expect(result).toEqual(failed(`No condition 'MyCondition' found`));
     });
 
     test('errors if condition evaluates to a non-boolean', async () => {
-        const tc = new TestContext({ conditions: { MyCondition: 'OOPS' } });
-        const result = runIntrinsic(intrinsics.fnIf, tc, ['MyCondition', 'yes', 'no']);
+        const tc = new TestContext({ conditions: { 'test-stack': { MyCondition: 'OOPS' } } });
+        const result = runIntrinsic(intrinsics.fnIf, tc, ['MyCondition', 'yes', 'no'], 'test-stack');
         expect(result).toEqual(failed(`Expected a boolean, got string`));
     });
 });
@@ -40,37 +40,37 @@ describe('Fn::If', () => {
 describe('Fn::Or', () => {
     test('picks true', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnOr, tc, [true, false, true]);
+        const result = runIntrinsic(intrinsics.fnOr, tc, [true, false, true], 'test-stack');
         expect(result).toEqual(ok(true));
     });
 
     test('picks false', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnOr, tc, [false, false, false]);
+        const result = runIntrinsic(intrinsics.fnOr, tc, [false, false, false], 'test-stack');
         expect(result).toEqual(ok(false));
     });
 
     test('picks true from inner Condition', async () => {
-        const tc = new TestContext({ conditions: { MyCondition: true } });
-        const result = runIntrinsic(intrinsics.fnOr, tc, [false, { Condition: 'MyCondition' }]);
+        const tc = new TestContext({ conditions: { 'test-stack': { MyCondition: true } } });
+        const result = runIntrinsic(intrinsics.fnOr, tc, [false, { Condition: 'MyCondition' }], 'test-stack');
         expect(result).toEqual(ok(true));
     });
 
     test('picks false with inner Condition', async () => {
-        const tc = new TestContext({ conditions: { MyCondition: false } });
-        const result = runIntrinsic(intrinsics.fnOr, tc, [false, { Condition: 'MyCondition' }]);
+        const tc = new TestContext({ conditions: { 'test-stack': { MyCondition: false } } });
+        const result = runIntrinsic(intrinsics.fnOr, tc, [false, { Condition: 'MyCondition' }], 'test-stack');
         expect(result).toEqual(ok(false));
     });
 
     test('has to have at least two arguments', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnOr, tc, [false]);
+        const result = runIntrinsic(intrinsics.fnOr, tc, [false], 'test-stack');
         expect(result).toEqual(failed(`Fn::Or expects at least 2 params, got 1`));
     });
 
     test('short-cirtcuits evaluation if true is found', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnOr, tc, [true, { Condition: 'DoesNotExist' }]);
+        const result = runIntrinsic(intrinsics.fnOr, tc, [true, { Condition: 'DoesNotExist' }], 'test-stack');
         expect(result).toEqual(ok(true));
     });
 });
@@ -78,37 +78,37 @@ describe('Fn::Or', () => {
 describe('Fn::And', () => {
     test('picks true', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnAnd, tc, [true, true, true]);
+        const result = runIntrinsic(intrinsics.fnAnd, tc, [true, true, true], 'test-stack');
         expect(result).toEqual(ok(true));
     });
 
     test('picks false', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnAnd, tc, [true, false, true]);
+        const result = runIntrinsic(intrinsics.fnAnd, tc, [true, false, true], 'test-stack');
         expect(result).toEqual(ok(false));
     });
 
     test('picks true from inner Condition', async () => {
-        const tc = new TestContext({ conditions: { MyCondition: true } });
-        const result = runIntrinsic(intrinsics.fnAnd, tc, [true, { Condition: 'MyCondition' }]);
+        const tc = new TestContext({ conditions: { 'test-stack': { MyCondition: true } } });
+        const result = runIntrinsic(intrinsics.fnAnd, tc, [true, { Condition: 'MyCondition' }], 'test-stack');
         expect(result).toEqual(ok(true));
     });
 
     test('picks false with inner Condition', async () => {
-        const tc = new TestContext({ conditions: { MyCondition: false } });
-        const result = runIntrinsic(intrinsics.fnAnd, tc, [true, { Condition: 'MyCondition' }]);
+        const tc = new TestContext({ conditions: { 'test-stack': { MyCondition: false } } });
+        const result = runIntrinsic(intrinsics.fnAnd, tc, [true, { Condition: 'MyCondition' }], 'test-stack');
         expect(result).toEqual(ok(false));
     });
 
     test('has to have at least two arguments', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnAnd, tc, [false]);
+        const result = runIntrinsic(intrinsics.fnAnd, tc, [false], 'test-stack');
         expect(result).toEqual(failed(`Fn::And expects at least 2 params, got 1`));
     });
 
     test('short-cirtcuits evaluation if false is found', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnAnd, tc, [false, { Condition: 'DoesNotExist' }]);
+        const result = runIntrinsic(intrinsics.fnAnd, tc, [false, { Condition: 'DoesNotExist' }], 'test-stack');
         expect(result).toEqual(ok(false));
     });
 });
@@ -116,31 +116,31 @@ describe('Fn::And', () => {
 describe('Fn::Not', () => {
     test('inverts false', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnNot, tc, [true]);
+        const result = runIntrinsic(intrinsics.fnNot, tc, [true], 'test-stack');
         expect(result).toEqual(ok(false));
     });
 
     test('inverts true', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnNot, tc, [false]);
+        const result = runIntrinsic(intrinsics.fnNot, tc, [false], 'test-stack');
         expect(result).toEqual(ok(true));
     });
 
     test('inverts a false Condition', async () => {
-        const tc = new TestContext({ conditions: { MyCondition: false } });
-        const result = runIntrinsic(intrinsics.fnNot, tc, [{ Condition: 'MyCondition' }]);
+        const tc = new TestContext({ conditions: { 'test-stack': { MyCondition: false } } });
+        const result = runIntrinsic(intrinsics.fnNot, tc, [{ Condition: 'MyCondition' }], 'test-stack');
         expect(result).toEqual(ok(true));
     });
 
     test('inverts a true Condition', async () => {
-        const tc = new TestContext({ conditions: { MyCondition: true } });
-        const result = runIntrinsic(intrinsics.fnNot, tc, [{ Condition: 'MyCondition' }]);
+        const tc = new TestContext({ conditions: { 'test-stack': { MyCondition: true } } });
+        const result = runIntrinsic(intrinsics.fnNot, tc, [{ Condition: 'MyCondition' }], 'test-stack');
         expect(result).toEqual(ok(false));
     });
 
     test('requires a boolean', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnNot, tc, ['ok']);
+        const result = runIntrinsic(intrinsics.fnNot, tc, ['ok'], 'test-stack');
         expect(result).toEqual(failed(`Expected a boolean, got string`));
     });
 });
@@ -148,31 +148,31 @@ describe('Fn::Not', () => {
 describe('Fn::Equals', () => {
     test('detects equal strings', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnEquals, tc, ['a', 'a']);
+        const result = runIntrinsic(intrinsics.fnEquals, tc, ['a', 'a'], 'test-stack');
         expect(result).toEqual(ok(true));
     });
 
     test('detects unequal strings', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnEquals, tc, ['a', 'b']);
+        const result = runIntrinsic(intrinsics.fnEquals, tc, ['a', 'b'], 'test-stack');
         expect(result).toEqual(ok(false));
     });
 
     test('detects equal objects', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnEquals, tc, [{ x: 'a' }, { x: 'a' }]);
+        const result = runIntrinsic(intrinsics.fnEquals, tc, [{ x: 'a' }, { x: 'a' }], 'test-stack');
         expect(result).toEqual(ok(true));
     });
 
     test('detects unequal objects', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnEquals, tc, [{ x: 'a' }, { x: 'b' }]);
+        const result = runIntrinsic(intrinsics.fnEquals, tc, [{ x: 'a' }, { x: 'b' }], 'test-stack');
         expect(result).toEqual(ok(false));
     });
 
     test('insists on two arguments', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.fnEquals, tc, [1]);
+        const result = runIntrinsic(intrinsics.fnEquals, tc, [1], 'test-stack');
         expect(result).toEqual(failed(`Fn::Equals expects exactly 2 params, got 1`));
     });
 });
@@ -181,53 +181,59 @@ describe('Ref', () => {
     test('resolves a parameter by its logical ID', async () => {
         const tc = new TestContext({
             parameters: {
-                MyParam: { id: 'MyParam', Type: 'String', Default: 'MyParamValue' },
+                'test-stack': { MyParam: { id: 'MyParam', Type: 'String', Default: 'MyParamValue' } },
             },
         });
-        const result = runIntrinsic(intrinsics.ref, tc, ['MyParam']);
+        const result = runIntrinsic(intrinsics.ref, tc, ['MyParam'], 'test-stack');
         expect(result).toEqual(ok('MyParamValue'));
     });
 
     test('respects "id" resource mapping provided by the user', async () => {
         const tc = new TestContext({
             resources: {
-                MyRes: {
-                    resource: <any>{},
-                    resourceType: 'AWS::S3::Bucket',
-                    attributes: {
-                        id: 'myID',
+                'test-stack': {
+                    MyRes: {
+                        resource: <any>{},
+                        resourceType: 'AWS::S3::Bucket',
+                        attributes: {
+                            id: 'myID',
+                        },
                     },
                 },
             },
         });
-        const result = runIntrinsic(intrinsics.ref, tc, ['MyRes']);
+        const result = runIntrinsic(intrinsics.ref, tc, ['MyRes'], 'test-stack');
         expect(result).toEqual(ok('myID'));
     });
 
     test('resolves a CustomResource to its physical ID', async () => {
         const tc = new TestContext({
             resources: {
-                MyRes: {
-                    resource: <any>{
-                        __pulumiType: (<any>ccapi.cloudformation.CustomResourceEmulator).__pulumiType,
-                        physicalResourceId: 'physicalID',
+                'test-stack': {
+                    MyRes: {
+                        resource: <any>{
+                            __pulumiType: (<any>ccapi.cloudformation.CustomResourceEmulator).__pulumiType,
+                            physicalResourceId: 'physicalID',
+                        },
+                        resourceType: 'AWS::CloudFormation::CustomResource',
                     },
-                    resourceType: 'AWS::CloudFormation::CustomResource',
                 },
             },
         });
-        const result = runIntrinsic(intrinsics.ref, tc, ['MyRes']);
+        const result = runIntrinsic(intrinsics.ref, tc, ['MyRes'], 'test-stack');
         expect(result).toEqual(ok('physicalID'));
     });
 
     test('fails if Pulumi metadata indicates Ref is not supported', async () => {
         const tc = new TestContext({
             resources: {
-                MyRes: {
-                    resource: <any>{
-                        __pulumiType: (<any>ccapi.s3.Bucket).__pulumiType,
+                'test-stack': {
+                    MyRes: {
+                        resource: <any>{
+                            __pulumiType: (<any>ccapi.s3.Bucket).__pulumiType,
+                        },
+                        resourceType: 'AWS::S3::Bucket',
                     },
-                    resourceType: 'AWS::S3::Bucket',
                 },
             },
             pulumiMetadata: {
@@ -240,19 +246,21 @@ describe('Ref', () => {
                 },
             },
         });
-        const result = runIntrinsic(intrinsics.ref, tc, ['MyRes']);
+        const result = runIntrinsic(intrinsics.ref, tc, ['MyRes'], 'test-stack');
         expect(result).toEqual(failed('Ref intrinsic is not supported for the AWS::S3::Bucket resource type'));
     });
 
     test('resolves to a property value indicated by Pulumi metadata', async () => {
         const tc = new TestContext({
             resources: {
-                MyRes: {
-                    resource: <any>{
-                        stageName: 'my-stage',
-                        __pulumiType: (<any>ccapi.apigateway.Stage).__pulumiType,
+                'test-stack': {
+                    MyRes: {
+                        resource: <any>{
+                            stageName: 'my-stage',
+                            __pulumiType: (<any>ccapi.apigateway.Stage).__pulumiType,
+                        },
+                        resourceType: 'AWS::ApiGateway::Stage',
                     },
-                    resourceType: 'AWS::ApiGateway::Stage',
                 },
             },
             pulumiMetadata: {
@@ -265,19 +273,21 @@ describe('Ref', () => {
                 },
             },
         });
-        const result = runIntrinsic(intrinsics.ref, tc, ['MyRes']);
+        const result = runIntrinsic(intrinsics.ref, tc, ['MyRes'], 'test-stack');
         expect(result).toEqual(ok('my-stage'));
     });
 
     test('does not use Pulumi metadata for AWS provider resource', async () => {
         const tc = new TestContext({
             resources: {
-                MyRes: {
-                    resource: <any>{
-                        id: 'my-stage',
-                        __pulumiType: (<any>aws.apigateway.Stage).__pulumiType,
+                'test-stack': {
+                    MyRes: {
+                        resource: <any>{
+                            id: 'my-stage',
+                            __pulumiType: (<any>aws.apigateway.Stage).__pulumiType,
+                        },
+                        resourceType: 'AWS::ApiGateway::Stage',
                     },
-                    resourceType: 'AWS::ApiGateway::Stage',
                 },
             },
             pulumiMetadata: {
@@ -290,20 +300,22 @@ describe('Ref', () => {
                 },
             },
         });
-        const result = runIntrinsic(intrinsics.ref, tc, ['MyRes']);
+        const result = runIntrinsic(intrinsics.ref, tc, ['MyRes'], 'test-stack');
         expect(result).toEqual(ok('my-stage'));
     });
 
     test('resolves to a join of several property values indicated by Pulumi metadata', async () => {
         const tc = new TestContext({
             resources: {
-                MyRes: {
-                    resource: <any>{
-                        roleName: 'my-role',
-                        policyName: 'my-policy',
-                        __pulumiType: (<any>ccapi.iam.RolePolicy).__pulumiType,
+                'test-stack': {
+                    MyRes: {
+                        resource: <any>{
+                            roleName: 'my-role',
+                            policyName: 'my-policy',
+                            __pulumiType: (<any>ccapi.iam.RolePolicy).__pulumiType,
+                        },
+                        resourceType: 'AWS::IAM::RolePolicy',
                     },
-                    resourceType: 'AWS::IAM::RolePolicy',
                 },
             },
             pulumiMetadata: {
@@ -317,28 +329,28 @@ describe('Ref', () => {
                 },
             },
         });
-        const result = runIntrinsic(intrinsics.ref, tc, ['MyRes']);
+        const result = runIntrinsic(intrinsics.ref, tc, ['MyRes'], 'test-stack');
         expect(result).toEqual(ok('my-policy|my-role'));
     });
 
     test('fails if called with an ID that does not resolve', async () => {
         const tc = new TestContext({});
-        const result = runIntrinsic(intrinsics.ref, tc, ['MyParam']);
+        const result = runIntrinsic(intrinsics.ref, tc, ['MyParam'], 'test-stack');
         expect(result).toEqual(
-            failed('Ref intrinsic unable to resolve MyParam: not a known logical resource or parameter reference'),
+            failed('Ref intrinsic unable to resolve MyParam in stack test-stack: not a known logical resource or parameter reference'),
         );
     });
 
     test('evaluates inner expressions before resolving', async () => {
         const tc = new TestContext({
             parameters: {
-                MyParam: { id: 'MyParam', Type: 'String', Default: 'MyParamValue' },
+                'test-stack': { MyParam: { id: 'MyParam', Type: 'String', Default: 'MyParamValue' } },
             },
             conditions: {
-                MyCondition: true,
+                'test-stack': { MyCondition: true },
             },
         });
-        const result = runIntrinsic(intrinsics.ref, tc, [{ 'Fn::If': ['MyCondition', 'MyParam', 'MyParam2'] }]);
+        const result = runIntrinsic(intrinsics.ref, tc, [{ 'Fn::If': ['MyCondition', 'MyParam', 'MyParam2'] }], 'test-stack');
         expect(result).toEqual(ok('MyParamValue'));
     });
 
@@ -346,10 +358,10 @@ describe('Ref', () => {
         const stackNodeId = 'stackNodeId';
         const tc = new TestContext({
             parameters: {
-                MyParam: { id: 'MyParam', Type: 'String', Default: 'MyParamValue' },
+                'test-stack': { MyParam: { id: 'MyParam', Type: 'String', Default: 'MyParamValue' } },
             },
             conditions: {
-                MyCondition: true,
+                'test-stack': { MyCondition: true },
             },
             accountId: '012345678901',
             region: 'us-west-2',
@@ -358,24 +370,24 @@ describe('Ref', () => {
             stackNodeId: stackNodeId,
         });
 
-        expect(runIntrinsic(intrinsics.ref, tc, ['AWS::AccountId'])).toEqual(ok('012345678901'));
-        expect(runIntrinsic(intrinsics.ref, tc, ['AWS::Region'])).toEqual(ok('us-west-2'));
-        expect(runIntrinsic(intrinsics.ref, tc, ['AWS::Partition'])).toEqual(ok('aws-us-gov'));
-        expect(runIntrinsic(intrinsics.ref, tc, ['AWS::URLSuffix'])).toEqual(ok('amazonaws.com.cn'));
-        expect(runIntrinsic(intrinsics.ref, tc, ['AWS::NoValue'])).toEqual(ok(undefined));
+        expect(runIntrinsic(intrinsics.ref, tc, ['AWS::AccountId'], 'test-stack')).toEqual(ok('012345678901'));
+        expect(runIntrinsic(intrinsics.ref, tc, ['AWS::Region'], 'test-stack')).toEqual(ok('us-west-2'));
+        expect(runIntrinsic(intrinsics.ref, tc, ['AWS::Partition'], 'test-stack')).toEqual(ok('aws-us-gov'));
+        expect(runIntrinsic(intrinsics.ref, tc, ['AWS::URLSuffix'], 'test-stack')).toEqual(ok('amazonaws.com.cn'));
+        expect(runIntrinsic(intrinsics.ref, tc, ['AWS::NoValue'], 'test-stack')).toEqual(ok(undefined));
 
-        expect(runIntrinsic(intrinsics.ref, tc, ['AWS::NotificationARNs'])).toEqual(
+        expect(runIntrinsic(intrinsics.ref, tc, ['AWS::NotificationARNs'], 'test-stack')).toEqual(
             failed('AWS::NotificationARNs pseudo-parameter is not yet supported in pulumi-cdk'),
         );
 
         // These are approximations; testing the current behavior for completeness sake.
-        expect(runIntrinsic(intrinsics.ref, tc, ['AWS::StackId'])).toEqual(ok(stackNodeId));
-        expect(runIntrinsic(intrinsics.ref, tc, ['AWS::StackName'])).toEqual(ok(stackNodeId));
+        expect(runIntrinsic(intrinsics.ref, tc, ['AWS::StackId'], 'test-stack')).toEqual(ok(stackNodeId));
+        expect(runIntrinsic(intrinsics.ref, tc, ['AWS::StackName'], 'test-stack')).toEqual(ok(stackNodeId));
     });
 });
 
-function runIntrinsic(fn: intrinsics.Intrinsic, tc: TestContext, args: intrinsics.Expression[]): TestResult<any> {
-    const result: TestResult<any> = <any>fn.evaluate(tc, args);
+function runIntrinsic(fn: intrinsics.Intrinsic, tc: TestContext, args: intrinsics.Expression[], stackPath: string): TestResult<any> {
+    const result: TestResult<any> = <any>fn.evaluate(tc, args, stackPath);
     return result;
 }
 
@@ -389,15 +401,19 @@ function failed<T>(errorMessage: string): TestResult<T> {
     return { ok: false, errorMessage: errorMessage };
 }
 
+interface StackNode<T> {
+    [stackPath: string]: { [id: string]: T };
+}
+
 class TestContext implements intrinsics.IntrinsicContext {
     accountId: string;
     region: string;
     partition: string;
     urlSuffix: string;
     stackNodeId: string;
-    conditions: { [id: string]: intrinsics.Expression };
-    parameters: { [id: CloudFormationParameterLogicalId]: CloudFormationParameterWithId };
-    resources: { [id: string]: Mapping<pulumi.Resource> };
+    conditions: StackNode<intrinsics.Expression>;
+    parameters: StackNode<CloudFormationParameter & { id: string }>;
+    resources: StackNode<Mapping<pulumi.Resource>>;
     pulumiMetadata: { [cfnType: string]: PulumiResource };
 
     constructor(args: {
@@ -406,9 +422,9 @@ class TestContext implements intrinsics.IntrinsicContext {
         partition?: string;
         urlSuffix?: string;
         stackNodeId?: string;
-        conditions?: { [id: string]: intrinsics.Expression };
-        parameters?: { [id: CloudFormationParameterLogicalId]: CloudFormationParameterWithId };
-        resources?: { [id: string]: Mapping<pulumi.Resource> };
+        conditions?: StackNode<intrinsics.Expression>;
+        parameters?: StackNode<CloudFormationParameter & { id: string }>;
+        resources?: StackNode<Mapping<pulumi.Resource>>;
         pulumiMetadata?: { [cfnType: string]: PulumiResource };
     }) {
         this.stackNodeId = args.stackNodeId || '';
@@ -432,9 +448,10 @@ class TestContext implements intrinsics.IntrinsicContext {
         }
     }
 
-    findParameter(parameterLogicalID: string): CloudFormationParameterWithId | undefined {
-        if (parameterLogicalID in this.parameters) {
-            return this.parameters[parameterLogicalID];
+    findParameter(stackAddress: StackAddress): CloudFormationParameterWithId | undefined {
+        const param = this.parameters?.[stackAddress.stackPath]?.[stackAddress.id];
+        if (param) {
+            return { ...param, stackAddress };
         }
     }
 
@@ -443,19 +460,15 @@ class TestContext implements intrinsics.IntrinsicContext {
         return this.succeed(param.Default!);
     }
 
-    findCondition(conditionName: string): intrinsics.Expression | undefined {
-        if (conditionName in this.conditions) {
-            return this.conditions[conditionName];
-        }
+    findCondition(stackAddress: StackAddress): intrinsics.Expression | undefined {
+        return this.conditions?.[stackAddress.stackPath]?.[stackAddress.id];
     }
 
-    findResourceMapping(resourceLogicalID: string): Mapping<pulumi.Resource> | undefined {
-        if (resourceLogicalID in this.resources) {
-            return this.resources[resourceLogicalID];
-        }
+    findResourceMapping(stackAddress: StackAddress): Mapping<pulumi.Resource> | undefined {
+        return this.resources?.[stackAddress.stackPath]?.[stackAddress.id];
     }
 
-    evaluate(expression: intrinsics.Expression): intrinsics.Result<any> {
+    evaluate(expression: intrinsics.Expression, stackPath: string): intrinsics.Result<any> {
         // Evaluate known heuristics.
         const known = [
             intrinsics.fnAnd,
@@ -469,7 +482,7 @@ class TestContext implements intrinsics.IntrinsicContext {
             for (const k of known) {
                 if (k.name === Object.keys(expression)[0]) {
                     const args = expression[k.name];
-                    return k.evaluate(this, args);
+                    return k.evaluate(this, args, stackPath);
                 }
             }
         }

--- a/tests/converters/secretsmanager-converter.test.ts
+++ b/tests/converters/secretsmanager-converter.test.ts
@@ -110,9 +110,10 @@ describe('SecretsManager tests', () => {
             id: 'stack',
             templatePath: 'test/stack',
             metadata: {
-                'stack/db': 'db',
-                'stack/secret': 'secret',
+                'stack/db': { stackPath: 'stack', id: 'db' },
+                'stack/secret': { stackPath: 'stack', id: 'secret' },
             },
+            nestedStacks: {},
             tree: {
                 path: 'stack',
                 id: 'stack',
@@ -180,7 +181,7 @@ describe('SecretsManager tests', () => {
         converter.convert(new Set());
 
         // THEN
-        const subnet = converter.resources.get('db')?.resource as native.rds.DbInstance;
+        const subnet = converter.resources.get({ stackPath: 'stack', id: 'db' })?.resource as native.rds.DbInstance;
         const cidrBlock = await promiseOf(subnet.masterUserSecret);
         expect(cidrBlock).toEqual('abcd');
     });
@@ -208,7 +209,7 @@ describe('SecretsManager tests', () => {
         converter.convert(new Set());
 
         // THEN
-        const subnet = converter.resources.get('db')?.resource as native.rds.DbInstance;
+        const subnet = converter.resources.get({ stackPath: 'stack', id: 'db' })?.resource as native.rds.DbInstance;
         const cidrBlock = await promiseOf(subnet.masterUserSecret);
         expect(cidrBlock).toEqual('abcd');
     });
@@ -222,7 +223,7 @@ describe('SecretsManager tests', () => {
         converter.convert(new Set());
 
         // THEN
-        const subnet = converter.resources.get('db')?.resource as native.rds.DbInstance;
+        const subnet = converter.resources.get({ stackPath: 'stack', id: 'db' })?.resource as native.rds.DbInstance;
         const cidrBlock = await promiseOf(subnet.masterUserSecret);
         expect(cidrBlock).toEqual('abcd');
     });
@@ -236,7 +237,7 @@ describe('SecretsManager tests', () => {
         converter.convert(new Set());
 
         // THEN
-        const subnet = converter.resources.get('db')?.resource as native.rds.DbInstance;
+        const subnet = converter.resources.get({ stackPath: 'stack', id: 'db' })?.resource as native.rds.DbInstance;
         const cidrBlock = await promiseOf(subnet.masterUserSecret);
         expect(cidrBlock).toEqual('abcd');
     });

--- a/tests/converters/ssm-converter.test.ts
+++ b/tests/converters/ssm-converter.test.ts
@@ -97,9 +97,10 @@ describe('SSM tests', () => {
             id: 'stack',
             templatePath: 'test/stack',
             metadata: {
-                'stack/db': 'db',
-                'stack/param': 'param',
+                'stack/db': { stackPath: 'stack', id: 'db' },
+                'stack/param': { stackPath: 'stack', id: 'param' },
             },
+            nestedStacks: {},
             tree: {
                 path: 'stack',
                 id: 'stack',
@@ -166,7 +167,7 @@ describe('SSM tests', () => {
         converter.convert(new Set());
 
         // THEN
-        const subnet = converter.resources.get('db')?.resource as native.rds.DbInstance;
+        const subnet = converter.resources.get({ stackPath: 'stack', id: 'db' })?.resource as native.rds.DbInstance;
         const cidrBlock = await promiseOf(subnet.masterUserSecret);
         expect(cidrBlock).toEqual('abcd');
     });
@@ -180,7 +181,7 @@ describe('SSM tests', () => {
         converter.convert(new Set());
 
         // THEN
-        const subnet = converter.resources.get('db')?.resource as native.rds.DbInstance;
+        const subnet = converter.resources.get({ stackPath: 'stack', id: 'db' })?.resource as native.rds.DbInstance;
         const cidrBlock = await promiseOf(subnet.masterUserSecret);
         expect(cidrBlock).toEqual('abcd');
     });
@@ -201,7 +202,7 @@ describe('SSM tests', () => {
         converter.convert(new Set());
 
         // THEN
-        const subnet = converter.resources.get('db')?.resource as native.rds.DbInstance;
+        const subnet = converter.resources.get({ stackPath: 'stack', id: 'db' })?.resource as native.rds.DbInstance;
         const value = await promiseOf(subnet.masterUserSecret);
         expect(value).toEqual('abcd');
     });
@@ -222,7 +223,7 @@ describe('SSM tests', () => {
         converter.convert(new Set());
 
         // THEN
-        const subnet = converter.resources.get('db')?.resource as native.rds.DbInstance;
+        const subnet = converter.resources.get({ stackPath: 'stack', id: 'db' })?.resource as native.rds.DbInstance;
         const value = await promiseOf(subnet.masterUserSecret);
         expect(value).toEqual('abcd,efgh');
     });

--- a/tests/graph.test.ts
+++ b/tests/graph.test.ts
@@ -24,9 +24,10 @@ describe('GraphBuilder', () => {
             id: 'stack',
             templatePath: 'test/stack',
             metadata: {
-                'stack/example-bucket/Resource': 'examplebucketC9DFA43E',
-                'stack/example-bucket/Policy/Resource': 'examplebucketPolicyE09B485E',
+                'stack/example-bucket/Resource': { stackPath: 'stack', id: 'examplebucketC9DFA43E' },
+                'stack/example-bucket/Policy/Resource': { stackPath: 'stack', id: 'examplebucketPolicyE09B485E' },
             },
+            nestedStacks: {},
             tree: {
                 path: 'stack',
                 id: 'stack',
@@ -109,7 +110,7 @@ describe('GraphBuilder', () => {
                     type: 'aws-cdk-lib:Stack',
                     parent: undefined,
                 },
-                logicalId: undefined,
+                resourceAddress: undefined,
                 resource: undefined,
                 incomingEdges: ['stack/example-bucket'],
                 outgoingEdges: [],
@@ -125,7 +126,7 @@ describe('GraphBuilder', () => {
                     id: 'example-bucket',
                     type: 'aws-cdk-lib/aws_s3:Bucket',
                 },
-                logicalId: undefined,
+                resourceAddress: undefined,
                 resource: undefined,
                 incomingEdges: ['stack/example-bucket/Resource', 'stack/example-bucket/Policy'],
                 outgoingEdges: ['stack'],
@@ -145,7 +146,7 @@ describe('GraphBuilder', () => {
                     Type: 'AWS::S3::Bucket',
                     Properties: {},
                 },
-                logicalId: 'examplebucketC9DFA43E',
+                resourceAddress: { stackPath: 'stack', id: 'examplebucketC9DFA43E' },
                 incomingEdges: ['stack/example-bucket/Policy/Resource'],
                 outgoingEdges: ['stack/example-bucket'],
             },
@@ -160,7 +161,7 @@ describe('GraphBuilder', () => {
                     id: 'Policy',
                     type: 'aws-cdk-lib/aws_s3:BucketPolicy',
                 },
-                logicalId: undefined,
+                resourceAddress: undefined,
                 resource: undefined,
                 incomingEdges: ['stack/example-bucket/Policy/Resource'],
                 outgoingEdges: ['stack/example-bucket'],
@@ -184,7 +185,7 @@ describe('GraphBuilder', () => {
                         },
                     },
                 },
-                logicalId: 'examplebucketPolicyE09B485E',
+                resourceAddress: { stackPath: 'stack', id: 'examplebucketPolicyE09B485E' },
                 incomingEdges: [],
                 outgoingEdges: ['stack/example-bucket/Policy', 'stack/example-bucket/Resource'],
             },
@@ -192,7 +193,7 @@ describe('GraphBuilder', () => {
     ])('Parses the graph correctly', (graph, path, expected) => {
         const actual = graph.nodes.find((node) => node.construct.path === path);
         expect(actual).toBeDefined();
-        expect(actual!.logicalId).toEqual(expected.logicalId);
+        expect(actual!.resourceAddress).toEqual(expected.resourceAddress);
         expect(actual!.resource).toEqual(expected.resource);
         expect(actual!.construct.parent?.id).toEqual(expected.construct.parent);
         expect(actual!.construct.type).toEqual(expected.construct.type);
@@ -251,10 +252,11 @@ test('vpc with ipv6 cidr block', () => {
             id: 'stack',
             templatePath: 'test/stack',
             metadata: {
-                'stack/vpc': 'vpc',
-                'stack/cidr': 'cidr',
-                'stack/other': 'other',
+                'stack/vpc': { stackPath: 'stack', id: 'vpc' },
+                'stack/cidr': { stackPath: 'stack', id: 'cidr' },
+                'stack/other': { stackPath: 'stack', id: 'other' },
             },
+            nestedStacks: {},
             tree: {
                 path: 'stack',
                 id: 'stack',
@@ -316,8 +318,8 @@ test('vpc with ipv6 cidr block', () => {
     expect(nodes[3].construct.type).toEqual('Resource');
 
     // The other resource should have it's edge swapped to the cidr resource
-    expect(Array.from(nodes[2].incomingEdges.values())[0].logicalId).toEqual('other');
-    expect(Array.from(nodes[3].outgoingEdges.values())[1].logicalId).toEqual('cidr');
+    expect(Array.from(nodes[2].incomingEdges.values())[0].resourceAddress).toEqual({ stackPath: 'stack', id: 'other' });
+    expect(Array.from(nodes[3].outgoingEdges.values())[1].resourceAddress).toEqual({ stackPath: 'stack', id: 'cidr' });
 });
 
 test('vpc with multiple ipv6 cidr blocks fails', () => {
@@ -327,11 +329,12 @@ test('vpc with multiple ipv6 cidr blocks fails', () => {
                 id: 'stack',
                 templatePath: 'test/stack',
                 metadata: {
-                    'stack/vpc': 'vpc',
-                    'stack/cidr': 'cidr',
-                    'stack/cidr2': 'cidr2',
-                    'stack/other': 'other',
+                    'stack/vpc': { stackPath: 'stack', id: 'vpc' },
+                    'stack/cidr': { stackPath: 'stack', id: 'cidr' },
+                    'stack/cidr2': { stackPath: 'stack', id: 'cidr2' },
+                    'stack/other': { stackPath: 'stack', id: 'other' },
                 },
+                nestedStacks: {},
                 tree: {
                     path: 'stack',
                     id: 'stack',
@@ -399,7 +402,7 @@ test('vpc with multiple ipv6 cidr blocks fails', () => {
                 dependencies: [],
             }),
         ).nodes;
-    }).toThrow(/VPC vpc already has a VPCCidrBlock/);
+    }).toThrow(/VPC vpc in stack stack already has a VPCCidrBlock/);
 });
 
 test('pulumi resource type name fallsback when fqn not available', () => {
@@ -410,9 +413,10 @@ test('pulumi resource type name fallsback when fqn not available', () => {
             id: 'stack',
             templatePath: 'test/stack',
             metadata: {
-                'stack/example-bucket/Resource': 'examplebucketC9DFA43E',
-                'stack/example-bucket/Policy/Resource': 'examplebucketPolicyE09B485E',
+                'stack/example-bucket/Resource': { stackPath: 'stack', id: 'examplebucketC9DFA43E' },
+                'stack/example-bucket/Policy/Resource': { stackPath: 'stack', id: 'examplebucketPolicyE09B485E' },
             },
+            nestedStacks: {},
             tree: {
                 path: 'stack',
                 id: 'stack',
@@ -490,7 +494,7 @@ test('parses custom resources', () => {
     const stackManifest = new StackManifest(props);
     const graph = GraphBuilder.build(stackManifest);
 
-    const deployWebsiteCR = graph.nodes.find((node) => node.logicalId === 'DeployWebsiteCustomResourceD116527B');
+    const deployWebsiteCR = graph.nodes.find((node) => node.resourceAddress?.id === 'DeployWebsiteCustomResourceD116527B');
     expect(deployWebsiteCR).toBeDefined();
     expect(deployWebsiteCR?.construct.type).toEqual('aws-cdk-lib:CfnResource');
     expect(deployWebsiteCR?.resource).toBeDefined();
@@ -506,7 +510,7 @@ test('parses custom resources', () => {
         'a386ba9b8c0d9b386083b2f6952db278a5a0ce88f497484eb5e62172219468fd.zip',
     ]);
 
-    const testRole = graph.nodes.find((node) => node.logicalId === 'CustomResourceRoleAB1EF463');
+    const testRole = graph.nodes.find((node) => node.resourceAddress?.id === 'CustomResourceRoleAB1EF463');
     expect(testRole).toBeDefined();
     const policies = testRole?.resource?.Properties?.Policies;
     expect(policies).toBeDefined();

--- a/tests/graph.test.ts
+++ b/tests/graph.test.ts
@@ -14,7 +14,7 @@
 
 import { GraphBuilder, GraphNode } from '../src/graph';
 import { ConstructTree, StackManifest, StackManifestProps } from '../src/assembly';
-import { createStackManifest } from './utils';
+import { createNestedStackManifest, createStackManifest } from './utils';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -26,8 +26,55 @@ describe('GraphBuilder', () => {
             metadata: {
                 'stack/example-bucket/Resource': { stackPath: 'stack', id: 'examplebucketC9DFA43E' },
                 'stack/example-bucket/Policy/Resource': { stackPath: 'stack', id: 'examplebucketPolicyE09B485E' },
+                'stack/nested.NestedStack/nested.NestedStackResource': { stackPath: 'stack', id: 'nested.NestedStackResource' },
+                'stack/nested/example-bucket/Resource': { stackPath: 'stack/nested', id: 'examplebucketdDE4DBE4F' },
+                'stack/nested/example-bucket/Policy/Resource': { stackPath: 'stack/nested', id: 'examplebucketPolicyC4E3BBE2F' },
+                'stack/output-bucket/Resource': { stackPath: 'stack', id: 'outputbucketC9DFA43E' },
+                'stack/output-bucket/Policy/Resource': { stackPath: 'stack', id: 'outputbucketPolicyE09B485E' },
             },
-            nestedStacks: {},
+            nestedStacks: {
+                'stack/nested': {
+                    logicalId: 'nested.NestedStack',
+                    Resources: {
+                        examplebucketdDE4DBE4F: {
+                            Type: 'AWS::S3::Bucket',
+                            Properties: {
+                                BucketName: {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            {
+                                                "Ref": "referencetostackexamplebucketC9DFA43ERef"
+                                            },
+                                            "-nested"
+                                        ]
+                                    ]
+                                }
+                            },
+                        },
+                        examplebucketPolicyC4E3BBE2F: {
+                            Type: 'AWS::S3::BucketPolicy',
+                            Properties: {
+                                Bucket: {
+                                    Ref: 'examplebucketdDE4DBE4F',
+                                },
+                            },
+                        },
+                    },
+                    Outputs: {
+                        stacknestedexamplebucketdDE4DBE4FRef: {
+                            Value: {
+                                Ref: 'examplebucketdDE4DBE4F',
+                            },
+                        },
+                    },
+                    Parameters: {
+                        referencetostackexamplebucketC9DFA43ERef: {
+                            Type: 'String',
+                        },
+                    },
+                },
+            },
             tree: {
                 path: 'stack',
                 id: 'stack',
@@ -74,6 +121,117 @@ describe('GraphBuilder', () => {
                             },
                         },
                     },
+                    nested: {
+                        id: 'nested',
+                        path: 'stack/nested',
+                        children: {
+                            'example-bucket': {
+                                id: 'example-bucket',
+                                path: 'stack/nested/example-bucket',
+                                constructInfo: {
+                                    fqn: 'aws-cdk-lib.aws_s3.Bucket',
+                                    version: '2.149.0',
+                                },
+                                children: {
+                                    Resource: {
+                                        id: 'Resource',
+                                        path: 'stack/nested/example-bucket/Resource',
+                                        attributes: {
+                                            'aws:cdk:cloudformation:type': 'AWS::S3::Bucket',
+                                        },
+                                        constructInfo: {
+                                            fqn: 'aws-cdk-lib.aws_s3.CfnBucket',
+                                            version: '2.149.0',
+                                        },
+                                    },
+                                    Policy: {
+                                        id: 'Policy',
+                                        path: 'stack/nested/example-bucket/Policy',
+                                        children: {
+                                            Resource: {
+                                                id: 'Resource',
+                                                path: 'stack/nested/example-bucket/Policy/Resource',
+                                                attributes: {
+                                                    'aws:cdk:cloudformation:type': 'AWS::S3::BucketPolicy',
+                                                },
+                                                constructInfo: {
+                                                    fqn: 'aws-cdk-lib.aws_s3.CfnBucketPolicy',
+                                                    version: '2.149.0',
+                                                },
+                                            },
+                                        },
+                                        constructInfo: {
+                                            fqn: 'aws-cdk-lib.aws_s3.BucketPolicy',
+                                            version: '2.149.0',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        constructInfo: {
+                            fqn: 'aws-cdk-lib.NestedStack',
+                            version: '2.149.0',
+                        },
+                    },
+                    "nested.NestedStack": {
+                        id: 'nested.NestedStack',
+                        path: 'stack/nested.NestedStack',
+                        children: {
+                            'nested.NestedStackResource': {
+                                id: 'nested.NestedStackResource',
+                                path: 'stack/nested.NestedStack/nested.NestedStackResource',
+                                attributes: {
+                                    'aws:cdk:cloudformation:type': 'AWS::CloudFormation::Stack',
+                                },
+                                constructInfo: {
+                                    fqn: 'aws-cdk-lib.CfnStack',
+                                    version: '2.149.0',
+                                },
+                            },
+                        }
+                    },
+                    'output-bucket': {
+                        id: 'output-bucket',
+                        path: 'stack/output-bucket',
+                        constructInfo: {
+                            fqn: 'aws-cdk-lib.aws_s3.Bucket',
+                            version: '2.149.0',
+                        },
+                        children: {
+                            Resource: {
+                                id: 'Resource',
+                                path: 'stack/output-bucket/Resource',
+                                attributes: {
+                                    'aws:cdk:cloudformation:type': 'AWS::S3::Bucket',
+                                },
+                                constructInfo: {
+                                    fqn: 'aws-cdk-lib.aws_s3.CfnBucket',
+                                    version: '2.149.0',
+                                },
+                            },
+                            Policy: {
+                                id: 'Policy',
+                                path: 'stack/output-bucket/Policy',
+                                children: {
+                                    Resource: {
+                                        id: 'Resource',
+                                        path: 'stack/output-bucket/Policy/Resource',
+                                        attributes: {
+                                            'aws:cdk:cloudformation:type': 'AWS::S3::BucketPolicy',
+                                        },
+                                        constructInfo: {
+                                            fqn: 'aws-cdk-lib.aws_s3.CfnBucketPolicy',
+                                            version: '2.149.0',
+                                        },
+                                    },
+                                },
+                                constructInfo: {
+                                    fqn: 'aws-cdk-lib.aws_s3.BucketPolicy',
+                                    version: '2.149.0',
+                                },
+                            },
+                        },
+                    },
                 },
                 constructInfo: {
                     fqn: 'aws-cdk-lib.Stack',
@@ -94,6 +252,43 @@ describe('GraphBuilder', () => {
                             },
                         },
                     },
+                    "nested.NestedStackResource": {
+                        Type: 'AWS::CloudFormation::Stack',
+                        Properties: {
+                            Parameters: {
+                                referencetostackexamplebucketC9DFA43ERef: {
+                                    Ref: 'examplebucketC9DFA43E',
+                                }
+                            }
+                        },
+                    },
+                    outputbucketC9DFA43E: {
+                        Type: 'AWS::S3::Bucket',
+                        Properties: {
+                            BucketName: {
+                                "Fn::Join": [
+                                    "",
+                                    [
+                                        {
+                                            "Fn::GetAtt": [
+                                                "nested.NestedStackResource",
+                                                "Outputs.stacknestedexamplebucketdDE4DBE4FRef"
+                                            ]
+                                        },
+                                        "-output"
+                                    ]
+                                ]
+                            }
+                        },
+                    },
+                    outputbucketPolicyE09B485E: {
+                        Type: 'AWS::S3::BucketPolicy',
+                        Properties: {
+                            Bucket: {
+                                Ref: 'outputbucketC9DFA43E',
+                            },
+                        },
+                    },
                 },
             },
             dependencies: [],
@@ -101,7 +296,6 @@ describe('GraphBuilder', () => {
     );
     test.each([
         [
-            nodes,
             'stack',
             {
                 construct: {
@@ -112,12 +306,11 @@ describe('GraphBuilder', () => {
                 },
                 resourceAddress: undefined,
                 resource: undefined,
-                incomingEdges: ['stack/example-bucket'],
+                incomingEdges: ['stack/example-bucket', 'stack/nested', 'stack/output-bucket'],
                 outgoingEdges: [],
             },
         ],
         [
-            nodes,
             'stack/example-bucket',
             {
                 construct: {
@@ -133,7 +326,6 @@ describe('GraphBuilder', () => {
             },
         ],
         [
-            nodes,
             'stack/example-bucket/Resource',
             {
                 construct: {
@@ -147,12 +339,11 @@ describe('GraphBuilder', () => {
                     Properties: {},
                 },
                 resourceAddress: { stackPath: 'stack', id: 'examplebucketC9DFA43E' },
-                incomingEdges: ['stack/example-bucket/Policy/Resource'],
+                incomingEdges: ['stack/example-bucket/Policy/Resource', 'stack/nested'],
                 outgoingEdges: ['stack/example-bucket'],
             },
         ],
         [
-            nodes,
             'stack/example-bucket/Policy',
             {
                 construct: {
@@ -168,7 +359,6 @@ describe('GraphBuilder', () => {
             },
         ],
         [
-            nodes,
             'stack/example-bucket/Policy/Resource',
             {
                 construct: {
@@ -190,15 +380,191 @@ describe('GraphBuilder', () => {
                 outgoingEdges: ['stack/example-bucket/Policy', 'stack/example-bucket/Resource'],
             },
         ],
-    ])('Parses the graph correctly', (graph, path, expected) => {
-        const actual = graph.nodes.find((node) => node.construct.path === path);
+        [
+            'stack/nested',
+            {
+                construct: {
+                    parent: 'stack',
+                    path: 'stack/nested',
+                    id: 'nested',
+                    type: 'Stack',
+                },
+                resourceAddress: { stackPath: 'stack', id: 'nested.NestedStackResource' },
+                resource: {
+                    Type: 'AWS::CloudFormation::Stack',
+                    Properties: {
+                        Parameters: {
+                            referencetostackexamplebucketC9DFA43ERef: {
+                                Ref: 'examplebucketC9DFA43E',
+                            }
+                        }
+                    },
+                },
+                incomingEdges: ['stack/nested/example-bucket', 'stack/output-bucket/Resource'],
+                outgoingEdges: ['stack', 'stack/example-bucket/Resource'], // the outgoing edge for 'stack/example-bucket/Resource' is the stack parameter
+            },
+        ],
+        [
+            'stack/nested/example-bucket',
+            {
+                construct: {
+                    parent: 'nested',
+                    path: 'stack/nested/example-bucket',
+                    id: 'example-bucket',
+                    type: 'aws-cdk-lib/aws_s3:Bucket',
+                },
+                resourceAddress: undefined,
+                resource: undefined,
+                incomingEdges: ['stack/nested/example-bucket/Resource', 'stack/nested/example-bucket/Policy'],
+                outgoingEdges: ['stack/nested'],
+            },
+        ],
+        [
+            'stack/nested/example-bucket/Resource',
+            {
+                construct: {
+                    parent: 'example-bucket',
+                    path: 'stack/nested/example-bucket/Resource',
+                    id: 'Resource',
+                    type: 'Bucket',
+                },
+                resourceAddress: { stackPath: 'stack/nested', id: 'examplebucketdDE4DBE4F' },
+                resource: {
+                    Type: 'AWS::S3::Bucket',
+                    Properties: {
+                        BucketName: {
+                            "Fn::Join": [
+                                "",
+                                [
+                                    {
+                                        "Ref": "referencetostackexamplebucketC9DFA43ERef"
+                                    },
+                                    "-nested"
+                                ]
+                            ]
+                        }
+                    },
+                },
+                incomingEdges: ['stack/nested/example-bucket/Policy/Resource', 'stack/output-bucket/Resource'], // the incoming edge for 'stack/output-bucket/Resource' is the stack output
+                outgoingEdges: ['stack/nested/example-bucket'],
+            },
+        ],
+        [
+            'stack/nested/example-bucket/Policy/Resource',
+            {
+                construct: {
+                    parent: 'Policy',
+                    path: 'stack/nested/example-bucket/Policy/Resource',
+                    id: 'Resource',
+                    type: 'BucketPolicy',
+                },
+                resourceAddress: { stackPath: 'stack/nested', id: 'examplebucketPolicyC4E3BBE2F' },
+                resource: {
+                    Type: 'AWS::S3::BucketPolicy',
+                    Properties: {
+                        Bucket: {
+                            Ref: 'examplebucketdDE4DBE4F',
+                        },
+                    },
+                },
+                incomingEdges: [],
+                outgoingEdges: ['stack/nested/example-bucket/Policy', 'stack/nested/example-bucket/Resource'],
+            },
+        ],
+        [
+            'stack/output-bucket',
+            {
+                construct: {
+                    parent: 'stack',
+                    path: 'stack/output-bucket',
+                    id: 'output-bucket',
+                    type: 'aws-cdk-lib/aws_s3:Bucket',
+                },
+                resourceAddress: undefined,
+                resource: undefined,
+                incomingEdges: ['stack/output-bucket/Resource', 'stack/output-bucket/Policy'],
+                outgoingEdges: ['stack'],
+            },
+        ],
+        [
+            'stack/output-bucket/Resource',
+            {
+                construct: {
+                    parent: 'output-bucket',
+                    path: 'stack/output-bucket/Resource',
+                    id: 'Resource',
+                    type: 'Bucket',
+                },
+                resourceAddress: { stackPath: 'stack', id: 'outputbucketC9DFA43E' },
+                resource: {
+                    Type: 'AWS::S3::Bucket',
+                    Properties: {
+                        BucketName: {
+                            "Fn::Join": [
+                                "",
+                                [
+                                    {
+                                        "Fn::GetAtt": [
+                                            "nested.NestedStackResource",
+                                            "Outputs.stacknestedexamplebucketdDE4DBE4FRef"
+                                        ]
+                                    },
+                                    "-output"
+                                ]
+                            ]
+                        }
+                    },
+                },
+                incomingEdges: ['stack/output-bucket/Policy/Resource'],
+                outgoingEdges: ['stack/output-bucket', 'stack/nested', 'stack/nested/example-bucket/Resource'], // the outgoing edge for 'stack/nested/example-bucket/Resource' is the nested stack output
+            },
+        ],
+        [
+            'stack/output-bucket/Policy',
+            {
+                construct: {
+                    parent: 'output-bucket',
+                    path: 'stack/output-bucket/Policy',
+                    id: 'Policy',
+                    type: 'aws-cdk-lib/aws_s3:BucketPolicy',
+                },
+                resourceAddress: undefined,
+                resource: undefined,
+                incomingEdges: ['stack/output-bucket/Policy/Resource'],
+                outgoingEdges: ['stack/output-bucket'],
+            },
+        ],
+        [
+            'stack/output-bucket/Policy/Resource',
+            {
+                construct: {
+                    parent: 'Policy',
+                    path: 'stack/output-bucket/Policy/Resource',
+                    id: 'Resource',
+                    type: 'BucketPolicy',
+                },
+                resourceAddress: { stackPath: 'stack', id: 'outputbucketPolicyE09B485E' },
+                resource: {
+                    Type: 'AWS::S3::BucketPolicy',
+                    Properties: {
+                        Bucket: {
+                            Ref: 'outputbucketC9DFA43E',
+                        },
+                    },
+                },
+                incomingEdges: [],
+                outgoingEdges: ['stack/output-bucket/Policy', 'stack/output-bucket/Resource'],
+            },
+        ],
+    ])('Parses the graph correctly: %s', (path, expected) => {
+        const actual = nodes.nodes.find((node) => node.construct.path === path);
         expect(actual).toBeDefined();
         expect(actual!.resourceAddress).toEqual(expected.resourceAddress);
         expect(actual!.resource).toEqual(expected.resource);
         expect(actual!.construct.parent?.id).toEqual(expected.construct.parent);
         expect(actual!.construct.type).toEqual(expected.construct.type);
-        expect(edgesToArray(actual!.incomingEdges)).toEqual(expected.incomingEdges);
-        expect(edgesToArray(actual!.outgoingEdges)).toEqual(expected.outgoingEdges);
+        expect(new Set(edgesToArray(actual!.incomingEdges))).toEqual(new Set(expected.incomingEdges));
+        expect(new Set(edgesToArray(actual!.outgoingEdges))).toEqual(new Set(expected.outgoingEdges));
     });
 
     test.each([
@@ -244,6 +610,213 @@ describe('GraphBuilder', () => {
         expect(edgesToArray(graph[2].incomingEdges)).toEqual([]);
         expect(edgesToArray(graph[2].outgoingEdges)).toEqual(['stack', 'stack/resource-1']);
     });
+});
+
+test.each([
+    [
+        'Ref stack input',
+        createNestedStackManifest({
+            nestedStackResourceProps: {
+                Parameters: {
+                    parentRef: { Ref: 'parent' },
+                }
+            },
+            nestedStackParameters: {
+                parentRef: {
+                    Type: 'String',
+                },
+            },
+            nestedResourceProps: {
+                BucketName: {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Ref": "parentRef"
+                            },
+                            "-nested"
+                        ]
+                    ]
+                }
+            },
+        }),
+        {
+            stackInput: true,
+            stackOutput: false,
+        }
+    ],
+    [
+        'GetAtt stack output',
+        createNestedStackManifest({
+            nestedStackOutputs: {
+                nestedStackOutput: {
+                    Value: {
+                        Ref: 'child',
+                    },
+                },
+            },
+            outputResourceProps: {
+                BucketName: {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Fn::GetAtt": [
+                                    "nested.NestedStackResource",
+                                    "Outputs.nestedStackOutput"
+                                ]
+                            },
+                            "-output"
+                        ]
+                    ]
+                }
+            }
+        }),
+        {
+            stackInput: false,
+            stackOutput: true,
+        }
+    ],
+    [
+        'Ref stack input and GetAtt stack output',
+        createNestedStackManifest({
+            nestedStackResourceProps: {
+                Parameters: {
+                    parentRef: { Ref: 'parent' },
+                }
+            },
+            nestedStackParameters: {
+                parentRef: {
+                    Type: 'String',
+                },
+            },
+            nestedResourceProps: {
+                BucketName: {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Ref": "parentRef"
+                            },
+                            "-nested"
+                        ]
+                    ]
+                }
+            },
+            nestedStackOutputs: {
+                nestedStackOutput: {
+                    Value: {
+                        Ref: 'child',
+                    },
+                },
+            },
+            outputResourceProps: {
+                BucketName: {
+                    "Fn::Join": [
+                        "",
+                        [
+                            {
+                                "Fn::GetAtt": [
+                                    "nested.NestedStackResource",
+                                    "Outputs.nestedStackOutput"
+                                ]
+                            },
+                            "-output"
+                        ]
+                    ]
+                }
+            }
+        }),
+        {
+            stackInput: true,
+            stackOutput: true,
+        }
+    ],
+    [
+        'Sub-Ref stack input',
+        createNestedStackManifest({
+            nestedStackResourceProps: {
+                Parameters: {
+                    parentRef: { 'Fn::Sub': ['test.${Domain}', { Domain: { Ref: 'parent' } }] },
+                }
+            },
+            nestedStackParameters: {
+                parentRef: {
+                    Type: 'String',
+                },
+            },
+            nestedResourceProps: {
+                BucketName: { 'Fn::Sub': ['sub.${Domain}', { Domain: { Ref: 'parentRef' } }] }
+            },
+        }),
+        {
+            stackInput: true,
+            stackOutput: false,
+        }
+    ],
+    [
+        'Sub-GetAtt stack output',
+        createNestedStackManifest({
+            nestedStackOutputs: {
+                nestedStackOutput: {
+                    Value: { 'Fn::Sub': ['test.${Domain}', { Domain: { Ref: 'child' } }] },
+                },
+            },
+            outputResourceProps: {
+                BucketName: {
+                    'Fn::Sub': ['sub.${Domain}', {
+                        Domain: {
+                            "Fn::GetAtt": [
+                                "nested.NestedStackResource",
+                                "Outputs.nestedStackOutput"
+                            ]
+                        }
+                    }]
+                },
+            }
+        }),
+        {
+            stackInput: false,
+            stackOutput: true,
+        }
+    ]
+])('nested stack adds edge for %s', (_name, stackManifest, expected) => {
+    const graph = GraphBuilder.build(stackManifest).nodes;
+    const childNode = graph.find((node) => node.construct.path === 'stack/nested/example-bucket/Resource');
+    const parentNode = graph.find((node) => node.construct.path === 'stack/example-bucket/Resource');
+    const outputNode = graph.find((node) => node.construct.path === 'stack/output-bucket/Resource');
+    const nestedStackNode = graph.find((node) => node.construct.path === 'stack/nested');
+
+    expect(new Set(edgesToArray(parentNode!.outgoingEdges))).toEqual(new Set(['stack/example-bucket']));
+    expect(new Set(edgesToArray(childNode!.outgoingEdges))).toEqual(new Set(['stack/nested/example-bucket']));
+    expect(new Set(edgesToArray(outputNode!.incomingEdges))).toEqual(new Set(['stack/output-bucket/Policy/Resource']));
+
+    if (expected.stackInput) {
+        // The nested stack should depend on its inputs
+        expect(new Set(edgesToArray(parentNode!.incomingEdges))).toEqual(new Set(['stack/nested', 'stack/example-bucket/Policy/Resource']));
+    } else {
+        expect(new Set(edgesToArray(parentNode!.incomingEdges))).toEqual(new Set(['stack/example-bucket/Policy/Resource']));
+    }
+
+    if (expected.stackOutput) {
+        // the resource using the nested stack output should depend on the nested stack and the child resource
+        expect(new Set(edgesToArray(nestedStackNode!.incomingEdges))).toEqual(new Set(['stack/nested/example-bucket', 'stack/output-bucket/Resource']));
+        expect(new Set(edgesToArray(childNode!.incomingEdges))).toEqual(new Set(['stack/nested/example-bucket/Policy/Resource', 'stack/output-bucket/Resource']));
+        expect(new Set(edgesToArray(outputNode!.outgoingEdges))).toEqual(new Set(['stack/output-bucket', 'stack/nested', 'stack/nested/example-bucket/Resource']));
+    } else {
+        expect(new Set(edgesToArray(nestedStackNode!.incomingEdges))).toEqual(new Set(['stack/nested/example-bucket']));
+        expect(new Set(edgesToArray(childNode!.incomingEdges))).toEqual(new Set(['stack/nested/example-bucket/Policy/Resource']));
+        expect(new Set(edgesToArray(outputNode!.outgoingEdges))).toEqual(new Set(['stack/output-bucket']));
+    }
+
+    // Nested stack outgoing edges depend on inputs and outputs
+    if (expected.stackInput && expected.stackOutput) {
+        expect(new Set(edgesToArray(nestedStackNode!.outgoingEdges))).toEqual(new Set(['stack', 'stack/example-bucket/Resource']));
+    } else if (expected.stackInput) {
+        expect(new Set(edgesToArray(nestedStackNode!.outgoingEdges))).toEqual(new Set(['stack', 'stack/example-bucket/Resource']));
+    } else if (expected.stackOutput) {
+        expect(new Set(edgesToArray(nestedStackNode!.outgoingEdges))).toEqual(new Set(['stack']));
+    }
 });
 
 test('vpc with ipv6 cidr block', () => {

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -189,6 +189,17 @@ export function setMocks(resources?: MockResourceArgs[], overrides?: { [pulumiTy
                             },
                         },
                     };
+                case 'aws-native:s3:Bucket':
+                    resources?.push(args);
+                    return {
+                        id: args.name + '_id',
+                        state: {
+                            ...args.inputs,
+                            id: args.name + '_id',
+                            arn: args.name + '_arn',
+                            bucketName: args.inputs?.bucketName ?? (args.name + '_name'),
+                        },
+                    };
                 default: {
                     resources?.push(args);
                     const attrName = args.type.split(':')[2];

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -27,8 +27,9 @@ describe('options', () => {
             id: 'stack',
             templatePath: 'test/stack',
             metadata: {
-                'stack/bucket': 'bucket',
+                'stack/bucket': { stackPath: 'stack', id: 'bucket' },
             },
+            nestedStacks: {},
             tree: {
                 path: 'stack',
                 id: 'stack',
@@ -74,8 +75,9 @@ describe('options', () => {
             id: 'stack',
             templatePath: 'test/stack',
             metadata: {
-                'stack/bucket': 'bucket',
+                'stack/bucket': { stackPath: 'stack', id: 'bucket' },
             },
+            nestedStacks: {},
             tree: {
                 path: 'stack',
                 id: 'stack',
@@ -121,8 +123,9 @@ describe('options', () => {
             id: 'stack',
             templatePath: 'test/stack',
             metadata: {
-                'stack/bucket': 'bucket',
+                'stack/bucket': { stackPath: 'stack', id: 'bucket' },
             },
+            nestedStacks: {},
             tree: {
                 path: 'stack',
                 id: 'stack',
@@ -168,8 +171,9 @@ describe('options', () => {
             id: 'stack',
             templatePath: 'test/stack',
             metadata: {
-                'stack/bucket': 'bucket',
+                'stack/bucket': { stackPath: 'stack', id: 'bucket' },
             },
+            nestedStacks: {},
             tree: {
                 path: 'stack',
                 id: 'stack',
@@ -215,8 +219,9 @@ describe('options', () => {
             id: 'stack',
             templatePath: 'test/stack',
             metadata: {
-                'stack/bucket': 'bucket',
+                'stack/bucket': { stackPath: 'stack', id: 'bucket' },
             },
+            nestedStacks: {},
             tree: {
                 path: 'stack',
                 id: 'stack',
@@ -261,8 +266,9 @@ describe('options', () => {
             id: 'stack',
             templatePath: 'test/stack',
             metadata: {
-                'stack/bucket': 'bucket',
+                'stack/bucket': { stackPath: 'stack', id: 'bucket' },
             },
+            nestedStacks: {},
             tree: {
                 path: 'stack',
                 id: 'stack',

--- a/tests/stack-map.test.ts
+++ b/tests/stack-map.test.ts
@@ -1,0 +1,101 @@
+import { StackMap } from '../src/stack-map';
+import { StackAddress } from '../src/assembly';
+
+describe('StackMap', () => {
+    let stackMap: StackMap<number>;
+    const stackAddress1: StackAddress = { stackPath: 'path1', id: 'id1' };
+    const stackAddress2: StackAddress = { stackPath: 'path2', id: 'id2' };
+
+    beforeEach(() => {
+        stackMap = new StackMap<number>();
+    });
+
+    test('should set and get values correctly', () => {
+        stackMap.set(stackAddress1, 1);
+        expect(stackMap.get(stackAddress1)).toBe(1);
+    });
+
+    test('should return undefined for non-existent keys', () => {
+        expect(stackMap.get(stackAddress1)).toBeUndefined();
+    });
+
+    test('should delete values correctly', () => {
+        stackMap.set(stackAddress1, 1);
+        expect(stackMap.delete(stackAddress1)).toBe(true);
+        expect(stackMap.get(stackAddress1)).toBeUndefined();
+    });
+
+    test('should return false when deleting non-existent keys', () => {
+        expect(stackMap.delete(stackAddress1)).toBe(false);
+    });
+
+    test('should check existence of keys correctly', () => {
+        stackMap.set(stackAddress1, 1);
+        expect(stackMap.has(stackAddress1)).toBe(true);
+        expect(stackMap.has(stackAddress2)).toBe(false);
+    });
+
+    test('should clear all values', () => {
+        stackMap.set(stackAddress1, 1);
+        stackMap.set(stackAddress2, 2);
+        stackMap.clear();
+        expect(stackMap.size).toBe(0);
+    });
+
+    test('should return the correct size', () => {
+        expect(stackMap.size).toBe(0);
+        stackMap.set(stackAddress1, 1);
+        expect(stackMap.size).toBe(1);
+    });
+
+    test('should iterate over entries correctly', () => {
+        stackMap.set(stackAddress1, 1);
+        stackMap.set(stackAddress2, 2);
+        const entries = Array.from(stackMap.entries());
+        expect(entries).toEqual([
+            [stackAddress1, 1],
+            [stackAddress2, 2]
+        ]);
+    });
+
+    test('should iterate over keys correctly', () => {
+        stackMap.set(stackAddress1, 1);
+        stackMap.set(stackAddress2, 2);
+        const keys = Array.from(stackMap.keys());
+        expect(keys).toEqual([stackAddress1, stackAddress2]);
+    });
+
+    test('should iterate over values correctly', () => {
+        stackMap.set(stackAddress1, 1);
+        stackMap.set(stackAddress2, 2);
+        const values = Array.from(stackMap.values());
+        expect(values).toEqual([1, 2]);
+    });
+
+    test('should execute forEach correctly', () => {
+        stackMap.set(stackAddress1, 1);
+        stackMap.set(stackAddress2, 2);
+        const mockCallback = jest.fn();
+        stackMap.forEach(mockCallback);
+        expect(mockCallback).toHaveBeenCalledTimes(2);
+        expect(mockCallback).toHaveBeenCalledWith(1, stackAddress1, stackMap);
+        expect(mockCallback).toHaveBeenCalledWith(2, stackAddress2, stackMap);
+    });
+
+    test('should execute forEachStackElement correctly for existing stackPath', () => {
+        stackMap.set(stackAddress1, 1);
+        stackMap.set({ stackPath: 'path1', id: 'id2' }, 2);
+        const mockCallback = jest.fn();
+        stackMap.forEachStackElement('path1', mockCallback);
+        expect(mockCallback).toHaveBeenCalledTimes(2);
+        expect(mockCallback).toHaveBeenCalledWith(1, { stackPath: 'path1', id: 'id1' }, stackMap);
+        expect(mockCallback).toHaveBeenCalledWith(2, { stackPath: 'path1', id: 'id2' }, stackMap);
+    });
+
+    test('should not execute forEachStackElement for non-existent stackPath', () => {
+        stackMap.set(stackAddress1, 1);
+        const mockCallback = jest.fn();
+        stackMap.forEachStackElement('nonExistentPath', mockCallback);
+        expect(mockCallback).not.toHaveBeenCalled();
+    });
+});

--- a/tests/test-data/custom-resource-stack/stack-manifest.json
+++ b/tests/test-data/custom-resource-stack/stack-manifest.json
@@ -2,21 +2,55 @@
     "id": "stack",
     "templatePath": "test/stack",
     "metadata": {
-        "s3deployment/WebsiteBucket/Resource": "WebsiteBucket75C24D94",
-        "s3deployment/WebsiteBucket/Policy/Resource": "WebsiteBucketPolicyE10E3262",
-        "s3deployment/WebsiteBucket/AutoDeleteObjectsCustomResource/Default": "WebsiteBucketAutoDeleteObjectsCustomResource8750E461",
-        "s3deployment/Custom::S3AutoDeleteObjectsCustomResourceProvider/Role": "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
-        "s3deployment/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
-        "s3deployment/DeployWebsite/AwsCliLayer/Resource": "DeployWebsiteAwsCliLayer17DBC421",
-        "s3deployment/DeployWebsite/CustomResource/Default": "DeployWebsiteCustomResourceD116527B",
-        "s3deployment/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole/Resource": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
-        "s3deployment/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole/DefaultPolicy/Resource": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
-        "s3deployment/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/Resource": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
-        "s3deployment/CustomResourceRole/Resource": "CustomResourceRoleAB1EF463"
+        "s3deployment/WebsiteBucket/Resource": {
+            "stackPath": "stack",
+            "id": "WebsiteBucket75C24D94"
+        },
+        "s3deployment/WebsiteBucket/Policy/Resource": {
+            "stackPath": "stack",
+            "id": "WebsiteBucketPolicyE10E3262"
+        },
+        "s3deployment/WebsiteBucket/AutoDeleteObjectsCustomResource/Default": {
+            "stackPath": "stack",
+            "id": "WebsiteBucketAutoDeleteObjectsCustomResource8750E461"
+        },
+        "s3deployment/Custom::S3AutoDeleteObjectsCustomResourceProvider/Role": {
+            "stackPath": "stack",
+            "id": "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092"
+        },
+        "s3deployment/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler": {
+            "stackPath": "stack",
+            "id": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F"
+        },
+        "s3deployment/DeployWebsite/AwsCliLayer/Resource": {
+            "stackPath": "stack",
+            "id": "DeployWebsiteAwsCliLayer17DBC421"
+        },
+        "s3deployment/DeployWebsite/CustomResource/Default": {
+            "stackPath": "stack",
+            "id": "DeployWebsiteCustomResourceD116527B"
+        },
+        "s3deployment/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole/Resource": {
+            "stackPath": "stack",
+            "id": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265"
+        },
+        "s3deployment/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole/DefaultPolicy/Resource": {
+            "stackPath": "stack",
+            "id": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF"
+        },
+        "s3deployment/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/Resource": {
+            "stackPath": "stack",
+            "id": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536"
+        },
+        "s3deployment/CustomResourceRole/Resource": {
+            "stackPath": "stack",
+            "id": "CustomResourceRoleAB1EF463"
+        }
     },
+    "nestedStacks": {},
     "tree": {
         "id": "stack",
-        "path": "",
+        "path": "stack",
         "children": {
             "s3deployment": {
                 "id": "s3deployment",

--- a/tests/test-data/nested-stack/manifest.json
+++ b/tests/test-data/nested-stack/manifest.json
@@ -1,0 +1,120 @@
+{
+  "version": "36.3.0",
+  "artifacts": {
+    "teststack.assets": {
+      "type": "cdk:asset-manifest",
+      "properties": {
+        "file": "teststack.assets.json"
+      }
+    },
+    "teststack": {
+      "type": "aws:cloudformation:stack",
+      "environment": "aws://616138583583/us-west-2",
+      "properties": {
+        "templateFile": "teststack.template.json",
+        "terminationProtection": false,
+        "validateOnSynth": false,
+        "stackTemplateAssetObjectUrl": "s3://pulumi-cdk-sted-sta-3ca1883d-staging/deploy-time/4cc5fad210e6468e30325de9b3f814b86a6bb8c61b9b5d7e8437c5290ab31f99.json"
+      },
+      "metadata": {
+        "/teststack/bucket/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "bucket"
+          }
+        ],
+        "/teststack/nesty/bucket/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "bucket43879C71"
+          }
+        ],
+        "/teststack/nesty/bucket/Policy/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "bucketPolicy638F945D"
+          }
+        ],
+        "/teststack/nesty/bucket/AutoDeleteObjectsCustomResource/Default": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "bucketAutoDeleteObjectsCustomResource3F4990B2"
+          }
+        ],
+        "/teststack/nesty/Custom::S3AutoDeleteObjectsCustomResourceProvider/Role": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092"
+          }
+        ],
+        "/teststack/nesty/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F"
+          }
+        ],
+        "/teststack/nesty/reference-to-teststackbucket4A009163Ref": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "referencetoteststackbucket4A009163Ref"
+          }
+        ],
+        "/teststack/nesty/teststacknestybucket3B9EFE19Ref": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "teststacknestybucket3B9EFE19Ref"
+          }
+        ],
+        "/teststack/nesty/teststacknestybucket3B9EFE19Arn": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "teststacknestybucket3B9EFE19Arn"
+          }
+        ],
+        "/teststack/nesty.NestedStack/nesty.NestedStackResource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "nestyNestedStacknestyNestedStackResource"
+          }
+        ],
+        "/teststack/DeployWebsite/AwsCliLayer/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "DeployWebsiteAwsCliLayer"
+          }
+        ],
+        "/teststack/DeployWebsite/CustomResource/Default": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "DeployWebsiteCustomResource"
+          }
+        ],
+        "/teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole"
+          }
+        ],
+        "/teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole/DefaultPolicy/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy"
+          }
+        ],
+        "/teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C"
+          }
+        ]
+      },
+      "displayName": "teststack"
+    },
+    "Tree": {
+      "type": "cdk:tree",
+      "properties": {
+        "file": "tree.json"
+      }
+    }
+  }
+}

--- a/tests/test-data/nested-stack/stack-manifest.json
+++ b/tests/test-data/nested-stack/stack-manifest.json
@@ -1,0 +1,1243 @@
+{
+  "dependencies": [],
+  "metadata": {
+    "teststack/bucket/Resource": {
+      "id": "bucket",
+      "stackPath": "teststack"
+    },
+    "teststack/nesty/bucket/Resource": {
+      "id": "bucket43879C71",
+      "stackPath": "teststack/nesty"
+    },
+    "teststack/nesty/bucket/Policy/Resource": {
+      "id": "bucketPolicy638F945D",
+      "stackPath": "teststack/nesty"
+    },
+    "teststack/nesty/bucket/AutoDeleteObjectsCustomResource/Default": {
+      "id": "bucketAutoDeleteObjectsCustomResource3F4990B2",
+      "stackPath": "teststack/nesty"
+    },
+    "teststack/nesty/Custom::S3AutoDeleteObjectsCustomResourceProvider/Role": {
+      "id": "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+      "stackPath": "teststack/nesty"
+    },
+    "teststack/nesty/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler": {
+      "id": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+      "stackPath": "teststack/nesty"
+    },
+    "teststack/nesty/reference-to-teststackbucket4A009163Ref": {
+      "id": "referencetoteststackbucket4A009163Ref",
+      "stackPath": "teststack/nesty"
+    },
+    "teststack/nesty/teststacknestybucket3B9EFE19Ref": {
+      "id": "teststacknestybucket3B9EFE19Ref",
+      "stackPath": "teststack/nesty"
+    },
+    "teststack/nesty/teststacknestybucket3B9EFE19Arn": {
+      "id": "teststacknestybucket3B9EFE19Arn",
+      "stackPath": "teststack/nesty"
+    },
+    "teststack/nesty.NestedStack/nesty.NestedStackResource": {
+      "id": "nestyNestedStacknestyNestedStackResource",
+      "stackPath": "teststack"
+    },
+    "teststack/DeployWebsite/AwsCliLayer/Resource": {
+      "id": "DeployWebsiteAwsCliLayer",
+      "stackPath": "teststack"
+    },
+    "teststack/DeployWebsite/CustomResource/Default": {
+      "id": "DeployWebsiteCustomResource",
+      "stackPath": "teststack"
+    },
+    "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole/Resource": {
+      "id": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole",
+      "stackPath": "teststack"
+    },
+    "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole/DefaultPolicy/Resource": {
+      "id": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy",
+      "stackPath": "teststack"
+    },
+    "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/Resource": {
+      "id": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C",
+      "stackPath": "teststack"
+    }
+  },
+  "templatePath": "teststack.template.json",
+  "id": "teststack",
+  "tree": {
+    "id": "teststack",
+    "path": "teststack",
+    "children": {
+      "bucket": {
+        "id": "bucket",
+        "path": "teststack/bucket",
+        "children": {
+          "Resource": {
+            "id": "Resource",
+            "path": "teststack/bucket/Resource",
+            "attributes": {
+              "aws:cdk:cloudformation:type": "AWS::S3::Bucket",
+              "aws:cdk:cloudformation:props": {}
+            },
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
+              "version": "2.149.0"
+            }
+          }
+        },
+        "constructInfo": {
+          "fqn": "aws-cdk-lib.aws_s3.Bucket",
+          "version": "2.149.0"
+        }
+      },
+      "nesty": {
+        "id": "nesty",
+        "path": "teststack/nesty",
+        "children": {
+          "bucket": {
+            "id": "bucket",
+            "path": "teststack/nesty/bucket",
+            "children": {
+              "Resource": {
+                "id": "Resource",
+                "path": "teststack/nesty/bucket/Resource",
+                "attributes": {
+                  "aws:cdk:cloudformation:type": "AWS::S3::Bucket",
+                  "aws:cdk:cloudformation:props": {
+                    "bucketName": {
+                      "Fn::Join": [
+                        "",
+                        [
+                          {
+                            "Ref": "referencetoteststackbucket4A009163Ref"
+                          },
+                          "-nested"
+                        ]
+                      ]
+                    },
+                    "publicAccessBlockConfiguration": {
+                      "blockPublicAcls": false,
+                      "blockPublicPolicy": false,
+                      "ignorePublicAcls": false,
+                      "restrictPublicBuckets": false
+                    },
+                    "tags": [
+                      {
+                        "key": "aws-cdk:auto-delete-objects",
+                        "value": "true"
+                      },
+                      {
+                        "key": "aws-cdk:cr-owned:043cc088",
+                        "value": "true"
+                      }
+                    ],
+                    "websiteConfiguration": {
+                      "indexDocument": "index.html"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
+                  "version": "2.149.0"
+                }
+              },
+              "Policy": {
+                "id": "Policy",
+                "path": "teststack/nesty/bucket/Policy",
+                "children": {
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "teststack/nesty/bucket/Policy/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::S3::BucketPolicy",
+                      "aws:cdk:cloudformation:props": {
+                        "bucket": {
+                          "Ref": "bucket43879C71"
+                        },
+                        "policyDocument": {
+                          "Statement": [
+                            {
+                              "Action": "s3:GetObject",
+                              "Effect": "Allow",
+                              "Principal": {
+                                "AWS": "*"
+                              },
+                              "Resource": {
+                                "Fn::Join": [
+                                  "",
+                                  [
+                                    {
+                                      "Fn::GetAtt": [
+                                        "bucket43879C71",
+                                        "Arn"
+                                      ]
+                                    },
+                                    "/*"
+                                  ]
+                                ]
+                              }
+                            },
+                            {
+                              "Action": [
+                                "s3:PutBucketPolicy",
+                                "s3:GetBucket*",
+                                "s3:List*",
+                                "s3:DeleteObject*"
+                              ],
+                              "Effect": "Allow",
+                              "Principal": {
+                                "AWS": {
+                                  "Fn::GetAtt": [
+                                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                                    "Arn"
+                                  ]
+                                }
+                              },
+                              "Resource": [
+                                {
+                                  "Fn::GetAtt": [
+                                    "bucket43879C71",
+                                    "Arn"
+                                  ]
+                                },
+                                {
+                                  "Fn::Join": [
+                                    "",
+                                    [
+                                      {
+                                        "Fn::GetAtt": [
+                                          "bucket43879C71",
+                                          "Arn"
+                                        ]
+                                      },
+                                      "/*"
+                                    ]
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "Version": "2012-10-17"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_s3.CfnBucketPolicy",
+                      "version": "2.149.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_s3.BucketPolicy",
+                  "version": "2.149.0"
+                }
+              },
+              "AutoDeleteObjectsCustomResource": {
+                "id": "AutoDeleteObjectsCustomResource",
+                "path": "teststack/nesty/bucket/AutoDeleteObjectsCustomResource",
+                "children": {
+                  "Default": {
+                    "id": "Default",
+                    "path": "teststack/nesty/bucket/AutoDeleteObjectsCustomResource/Default",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.CfnResource",
+                      "version": "2.149.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.CustomResource",
+                  "version": "2.149.0"
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.aws_s3.Bucket",
+              "version": "2.149.0"
+            }
+          },
+          "Custom::S3AutoDeleteObjectsCustomResourceProvider": {
+            "id": "Custom::S3AutoDeleteObjectsCustomResourceProvider",
+            "path": "teststack/nesty/Custom::S3AutoDeleteObjectsCustomResourceProvider",
+            "children": {
+              "Staging": {
+                "id": "Staging",
+                "path": "teststack/nesty/Custom::S3AutoDeleteObjectsCustomResourceProvider/Staging",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.AssetStaging",
+                  "version": "2.149.0"
+                }
+              },
+              "Role": {
+                "id": "Role",
+                "path": "teststack/nesty/Custom::S3AutoDeleteObjectsCustomResourceProvider/Role",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.CfnResource",
+                  "version": "2.149.0"
+                }
+              },
+              "Handler": {
+                "id": "Handler",
+                "path": "teststack/nesty/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.CfnResource",
+                  "version": "2.149.0"
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.CustomResourceProviderBase",
+              "version": "2.149.0"
+            }
+          },
+          "reference-to-teststackbucket4A009163Ref": {
+            "id": "reference-to-teststackbucket4A009163Ref",
+            "path": "teststack/nesty/reference-to-teststackbucket4A009163Ref",
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.CfnParameter",
+              "version": "2.156.0"
+            }
+          },
+          "teststacknestybucket3B9EFE19Ref": {
+            "id": "teststacknestybucket3B9EFE19Ref",
+            "path": "teststack/nesty/teststacknestybucket3B9EFE19Ref",
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.CfnOutput",
+              "version": "2.156.0"
+            }
+          },
+          "teststacknestybucket3B9EFE19Arn": {
+            "id": "teststacknestybucket3B9EFE19Arn",
+            "path": "teststack/nesty/teststacknestybucket3B9EFE19Arn",
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.CfnOutput",
+              "version": "2.156.0"
+            }
+          }
+        },
+        "constructInfo": {
+          "fqn": "aws-cdk-lib.NestedStack",
+          "version": "2.149.0"
+        }
+      },
+      "nesty.NestedStack": {
+        "id": "nesty.NestedStack",
+        "path": "teststack/nesty.NestedStack",
+        "children": {
+          "nesty.NestedStackResource": {
+            "id": "nesty.NestedStackResource",
+            "path": "teststack/nesty.NestedStack/nesty.NestedStackResource",
+            "attributes": {
+              "aws:cdk:cloudformation:type": "AWS::CloudFormation::Stack",
+              "aws:cdk:cloudformation:props": {
+                "parameters": {
+                  "referencetoteststackbucket4A009163Ref": {
+                    "Ref": "bucket"
+                  }
+                },
+                "templateUrl": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "https://s3.us-west-2.",
+                      {
+                        "Ref": "AWS::URLSuffix"
+                      },
+                      "/",
+                      {
+                        "Ref": {
+                          "PulumiOutput": 18
+                        }
+                      },
+                      "/",
+                      {
+                        "Ref": {
+                          "PulumiOutput": 19
+                        }
+                      }
+                    ]
+                  ]
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.CfnStack",
+              "version": "2.149.0"
+            }
+          }
+        },
+        "constructInfo": {
+          "fqn": "constructs.Construct",
+          "version": "10.3.0"
+        }
+      },
+      "DeployWebsite": {
+        "id": "DeployWebsite",
+        "path": "teststack/DeployWebsite",
+        "children": {
+          "AwsCliLayer": {
+            "id": "AwsCliLayer",
+            "path": "teststack/DeployWebsite/AwsCliLayer",
+            "children": {
+              "Code": {
+                "id": "Code",
+                "path": "teststack/DeployWebsite/AwsCliLayer/Code",
+                "children": {
+                  "Stage": {
+                    "id": "Stage",
+                    "path": "teststack/DeployWebsite/AwsCliLayer/Code/Stage",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.AssetStaging",
+                      "version": "2.149.0"
+                    }
+                  },
+                  "AssetBucket": {
+                    "id": "AssetBucket",
+                    "path": "teststack/DeployWebsite/AwsCliLayer/Code/AssetBucket",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_s3.BucketBase",
+                      "version": "2.149.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
+                  "version": "2.149.0"
+                }
+              },
+              "Resource": {
+                "id": "Resource",
+                "path": "teststack/DeployWebsite/AwsCliLayer/Resource",
+                "attributes": {
+                  "aws:cdk:cloudformation:type": "AWS::Lambda::LayerVersion",
+                  "aws:cdk:cloudformation:props": {
+                    "content": {
+                      "s3Bucket": {
+                        "Ref": {
+                          "PulumiOutput": 6
+                        }
+                      },
+                      "s3Key": {
+                        "Ref": {
+                          "PulumiOutput": 7
+                        }
+                      }
+                    },
+                    "description": "/opt/awscli/aws"
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
+                  "version": "2.149.0"
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.lambda_layer_awscli.AwsCliLayer",
+              "version": "2.149.0"
+            }
+          },
+          "CustomResourceHandler": {
+            "id": "CustomResourceHandler",
+            "path": "teststack/DeployWebsite/CustomResourceHandler",
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.aws_lambda.SingletonFunction",
+              "version": "2.149.0"
+            }
+          },
+          "Asset1": {
+            "id": "Asset1",
+            "path": "teststack/DeployWebsite/Asset1",
+            "children": {
+              "Stage": {
+                "id": "Stage",
+                "path": "teststack/DeployWebsite/Asset1/Stage",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.AssetStaging",
+                  "version": "2.149.0"
+                }
+              },
+              "AssetBucket": {
+                "id": "AssetBucket",
+                "path": "teststack/DeployWebsite/Asset1/AssetBucket",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_s3.BucketBase",
+                  "version": "2.149.0"
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
+              "version": "2.149.0"
+            }
+          },
+          "CustomResource": {
+            "id": "CustomResource",
+            "path": "teststack/DeployWebsite/CustomResource",
+            "children": {
+              "Default": {
+                "id": "Default",
+                "path": "teststack/DeployWebsite/CustomResource/Default",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.CfnResource",
+                  "version": "2.149.0"
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.CustomResource",
+              "version": "2.149.0"
+            }
+          }
+        },
+        "constructInfo": {
+          "fqn": "aws-cdk-lib.aws_s3_deployment.BucketDeployment",
+          "version": "2.149.0"
+        }
+      },
+      "Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C": {
+        "id": "Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C",
+        "path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C",
+        "children": {
+          "ServiceRole": {
+            "id": "ServiceRole",
+            "path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole",
+            "children": {
+              "ImportServiceRole": {
+                "id": "ImportServiceRole",
+                "path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole/ImportServiceRole",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.Resource",
+                  "version": "2.149.0"
+                }
+              },
+              "Resource": {
+                "id": "Resource",
+                "path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole/Resource",
+                "attributes": {
+                  "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                  "aws:cdk:cloudformation:props": {
+                    "assumeRolePolicyDocument": {
+                      "Statement": [
+                        {
+                          "Action": "sts:AssumeRole",
+                          "Effect": "Allow",
+                          "Principal": {
+                            "Service": "lambda.amazonaws.com"
+                          }
+                        }
+                      ],
+                      "Version": "2012-10-17"
+                    },
+                    "managedPolicyArns": [
+                      {
+                        "Fn::Join": [
+                          "",
+                          [
+                            "arn:",
+                            {
+                              "Ref": "AWS::Partition"
+                            },
+                            ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+                          ]
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                  "version": "2.149.0"
+                }
+              },
+              "DefaultPolicy": {
+                "id": "DefaultPolicy",
+                "path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole/DefaultPolicy",
+                "children": {
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole/DefaultPolicy/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::IAM::Policy",
+                      "aws:cdk:cloudformation:props": {
+                        "policyDocument": {
+                          "Statement": [
+                            {
+                              "Action": [
+                                "s3:GetObject*",
+                                "s3:GetBucket*",
+                                "s3:List*"
+                              ],
+                              "Effect": "Allow",
+                              "Resource": [
+                                {
+                                  "Fn::Join": [
+                                    "",
+                                    [
+                                      "arn:",
+                                      {
+                                        "Ref": "AWS::Partition"
+                                      },
+                                      ":s3:::",
+                                      {
+                                        "Ref": {
+                                          "PulumiOutput": 14
+                                        }
+                                      }
+                                    ]
+                                  ]
+                                },
+                                {
+                                  "Fn::Join": [
+                                    "",
+                                    [
+                                      "arn:",
+                                      {
+                                        "Ref": "AWS::Partition"
+                                      },
+                                      ":s3:::",
+                                      {
+                                        "Ref": {
+                                          "PulumiOutput": 14
+                                        }
+                                      },
+                                      "/*"
+                                    ]
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "Action": [
+                                "s3:GetObject*",
+                                "s3:GetBucket*",
+                                "s3:List*",
+                                "s3:DeleteObject*",
+                                "s3:PutObject",
+                                "s3:PutObjectLegalHold",
+                                "s3:PutObjectRetention",
+                                "s3:PutObjectTagging",
+                                "s3:PutObjectVersionTagging",
+                                "s3:Abort*"
+                              ],
+                              "Effect": "Allow",
+                              "Resource": [
+                                {
+                                  "Fn::GetAtt": [
+                                    "nestyNestedStacknestyNestedStackResource",
+                                    "Outputs.teststacknestybucket3B9EFE19Arn"
+                                  ]
+                                },
+                                {
+                                  "Fn::Join": [
+                                    "",
+                                    [
+                                      {
+                                        "Fn::GetAtt": [
+                                          "nestyNestedStacknestyNestedStackResource",
+                                          "Outputs.teststacknestybucket3B9EFE19Arn"
+                                        ]
+                                      },
+                                      "/*"
+                                    ]
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "Version": "2012-10-17"
+                        },
+                        "policyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy",
+                        "roles": [
+                          {
+                            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole"
+                          }
+                        ]
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
+                      "version": "2.149.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_iam.Policy",
+                  "version": "2.149.0"
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.aws_iam.Role",
+              "version": "2.149.0"
+            }
+          },
+          "Code": {
+            "id": "Code",
+            "path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/Code",
+            "children": {
+              "Stage": {
+                "id": "Stage",
+                "path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/Code/Stage",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.AssetStaging",
+                  "version": "2.149.0"
+                }
+              },
+              "AssetBucket": {
+                "id": "AssetBucket",
+                "path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/Code/AssetBucket",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_s3.BucketBase",
+                  "version": "2.149.0"
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
+              "version": "2.149.0"
+            }
+          },
+          "Resource": {
+            "id": "Resource",
+            "path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/Resource",
+            "attributes": {
+              "aws:cdk:cloudformation:type": "AWS::Lambda::Function",
+              "aws:cdk:cloudformation:props": {
+                "code": {
+                  "s3Bucket": {
+                    "Ref": {
+                      "PulumiOutput": 10
+                    }
+                  },
+                  "s3Key": {
+                    "Ref": {
+                      "PulumiOutput": 11
+                    }
+                  }
+                },
+                "environment": {
+                  "variables": {
+                    "AWS_CA_BUNDLE": "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+                  }
+                },
+                "handler": "index.handler",
+                "layers": [
+                  {
+                    "Ref": "DeployWebsiteAwsCliLayer"
+                  }
+                ],
+                "role": {
+                  "Fn::GetAtt": [
+                    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole",
+                    "Arn"
+                  ]
+                },
+                "runtime": "python3.9",
+                "timeout": 900
+              }
+            },
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
+              "version": "2.149.0"
+            }
+          }
+        },
+        "constructInfo": {
+          "fqn": "aws-cdk-lib.aws_lambda.Function",
+          "version": "2.149.0"
+        }
+      }
+    },
+    "constructInfo": {
+      "fqn": "aws-cdk-lib.Stack",
+      "version": "2.156.0"
+    }
+  },
+  "template": {
+    "Resources": {
+      "bucket": {
+        "Type": "AWS::S3::Bucket",
+        "UpdateReplacePolicy": "Retain",
+        "DeletionPolicy": "Retain",
+        "Metadata": {
+          "aws:cdk:path": "teststack/bucket/Resource"
+        }
+      },
+      "nestyNestedStacknestyNestedStackResource": {
+        "Type": "AWS::CloudFormation::Stack",
+        "Properties": {
+          "Parameters": {
+            "referencetoteststackbucket4A009163Ref": {
+              "Ref": "bucket"
+            }
+          },
+          "TemplateURL": {
+            "Fn::Join": [
+              "",
+              [
+                "https://s3.us-west-2.",
+                {
+                  "Ref": "AWS::URLSuffix"
+                },
+                "/",
+                "DUMMY",
+                "/",
+                "DUMMY"
+              ]
+            ]
+          }
+        },
+        "UpdateReplacePolicy": "Delete",
+        "DeletionPolicy": "Delete",
+        "Metadata": {
+          "aws:cdk:path": "teststack/nesty.NestedStack/nesty.NestedStackResource",
+          "aws:asset:path": "teststacknesty613E34DC.nested.template.json",
+          "aws:asset:property": "TemplateURL"
+        }
+      },
+      "DeployWebsiteAwsCliLayer": {
+        "Type": "AWS::Lambda::LayerVersion",
+        "Properties": {
+          "Content": {
+            "S3Bucket": "DUMMY",
+            "S3Key": "DUMMY"
+          },
+          "Description": "/opt/awscli/aws"
+        },
+        "Metadata": {
+          "aws:cdk:path": "teststack/DeployWebsite/AwsCliLayer/Resource",
+          "aws:asset:path": "asset.6620cb784ea0d3cf3a6e3e128827087f88e7e9999cd41b0be7c50431fbf12026.zip",
+          "aws:asset:is-bundled": false,
+          "aws:asset:property": "Content"
+        }
+      },
+      "DeployWebsiteCustomResource": {
+        "Type": "Custom::CDKBucketDeployment",
+        "Properties": {
+          "ServiceToken": {
+            "Fn::GetAtt": [
+              "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C",
+              "Arn"
+            ]
+          },
+          "SourceBucketNames": [
+            "DUMMY"
+          ],
+          "SourceObjectKeys": [
+            "DUMMY"
+          ],
+          "SourceMarkers": [
+            {}
+          ],
+          "DestinationBucketName": {
+            "Fn::GetAtt": [
+              "nestyNestedStacknestyNestedStackResource",
+              "Outputs.teststacknestybucket3B9EFE19Ref"
+            ]
+          },
+          "Prune": true
+        },
+        "UpdateReplacePolicy": "Delete",
+        "DeletionPolicy": "Delete",
+        "Metadata": {
+          "aws:cdk:path": "teststack/DeployWebsite/CustomResource/Default"
+        }
+      },
+      "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole": {
+        "Type": "AWS::IAM::Role",
+        "Properties": {
+          "AssumeRolePolicyDocument": {
+            "Statement": [
+              {
+                "Action": "sts:AssumeRole",
+                "Effect": "Allow",
+                "Principal": {
+                  "Service": "lambda.amazonaws.com"
+                }
+              }
+            ],
+            "Version": "2012-10-17"
+          },
+          "ManagedPolicyArns": [
+            {
+              "Fn::Join": [
+                "",
+                [
+                  "arn:",
+                  {
+                    "Ref": "AWS::Partition"
+                  },
+                  ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+                ]
+              ]
+            }
+          ]
+        },
+        "Metadata": {
+          "aws:cdk:path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole/Resource"
+        }
+      },
+      "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy": {
+        "Type": "AWS::IAM::Policy",
+        "Properties": {
+          "PolicyDocument": {
+            "Statement": [
+              {
+                "Action": [
+                  "s3:GetObject*",
+                  "s3:GetBucket*",
+                  "s3:List*"
+                ],
+                "Effect": "Allow",
+                "Resource": [
+                  {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition"
+                        },
+                        ":s3:::",
+                        "DUMMY"
+                      ]
+                    ]
+                  },
+                  {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition"
+                        },
+                        ":s3:::",
+                        "DUMMY",
+                        "/*"
+                      ]
+                    ]
+                  }
+                ]
+              },
+              {
+                "Action": [
+                  "s3:GetObject*",
+                  "s3:GetBucket*",
+                  "s3:List*",
+                  "s3:DeleteObject*",
+                  "s3:PutObject",
+                  "s3:PutObjectLegalHold",
+                  "s3:PutObjectRetention",
+                  "s3:PutObjectTagging",
+                  "s3:PutObjectVersionTagging",
+                  "s3:Abort*"
+                ],
+                "Effect": "Allow",
+                "Resource": [
+                  {
+                    "Fn::GetAtt": [
+                      "nestyNestedStacknestyNestedStackResource",
+                      "Outputs.teststacknestybucket3B9EFE19Arn"
+                    ]
+                  },
+                  {
+                    "Fn::Join": [
+                      "",
+                      [
+                        {
+                          "Fn::GetAtt": [
+                            "nestyNestedStacknestyNestedStackResource",
+                            "Outputs.teststacknestybucket3B9EFE19Arn"
+                          ]
+                        },
+                        "/*"
+                      ]
+                    ]
+                  }
+                ]
+              }
+            ],
+            "Version": "2012-10-17"
+          },
+          "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy",
+          "Roles": [
+            {
+              "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole"
+            }
+          ]
+        },
+        "Metadata": {
+          "aws:cdk:path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole/DefaultPolicy/Resource"
+        }
+      },
+      "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C": {
+        "Type": "AWS::Lambda::Function",
+        "Properties": {
+          "Code": {
+            "S3Bucket": "DUMMY",
+            "S3Key": "DUMMY"
+          },
+          "Environment": {
+            "Variables": {
+              "AWS_CA_BUNDLE": "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+            }
+          },
+          "Handler": "index.handler",
+          "Layers": [
+            {
+              "Ref": "DeployWebsiteAwsCliLayer"
+            }
+          ],
+          "Role": {
+            "Fn::GetAtt": [
+              "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole",
+              "Arn"
+            ]
+          },
+          "Runtime": "python3.9",
+          "Timeout": 900
+        },
+        "DependsOn": [
+          "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy",
+          "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole"
+        ],
+        "Metadata": {
+          "aws:cdk:path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/Resource",
+          "aws:asset:path": "asset.2d56e153cac88d3e0c2f842e8e6f6783b8725bf91f95e0673b4725448a56e96d",
+          "aws:asset:is-bundled": false,
+          "aws:asset:property": "Code"
+        }
+      }
+    }
+  },
+  "nestedStacks": {
+    "teststack/nesty": {
+      "Resources": {
+        "bucket43879C71": {
+          "Type": "AWS::S3::Bucket",
+          "Properties": {
+            "BucketName": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "referencetoteststackbucket4A009163Ref"
+                  },
+                  "-nested"
+                ]
+              ]
+            },
+            "PublicAccessBlockConfiguration": {
+              "BlockPublicAcls": false,
+              "BlockPublicPolicy": false,
+              "IgnorePublicAcls": false,
+              "RestrictPublicBuckets": false
+            },
+            "Tags": [
+              {
+                "Key": "aws-cdk:auto-delete-objects",
+                "Value": "true"
+              },
+              {
+                "Key": "aws-cdk:cr-owned:043cc088",
+                "Value": "true"
+              }
+            ],
+            "WebsiteConfiguration": {
+              "IndexDocument": "index.html"
+            }
+          },
+          "UpdateReplacePolicy": "Delete",
+          "DeletionPolicy": "Delete",
+          "Metadata": {
+            "aws:cdk:path": "teststack/nesty/bucket/Resource"
+          }
+        },
+        "bucketPolicy638F945D": {
+          "Type": "AWS::S3::BucketPolicy",
+          "Properties": {
+            "Bucket": {
+              "Ref": "bucket43879C71"
+            },
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "s3:GetObject",
+                  "Effect": "Allow",
+                  "Principal": {
+                    "AWS": "*"
+                  },
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        {
+                          "Fn::GetAtt": [
+                            "bucket43879C71",
+                            "Arn"
+                          ]
+                        },
+                        "/*"
+                      ]
+                    ]
+                  }
+                },
+                {
+                  "Action": [
+                    "s3:PutBucketPolicy",
+                    "s3:GetBucket*",
+                    "s3:List*",
+                    "s3:DeleteObject*"
+                  ],
+                  "Effect": "Allow",
+                  "Principal": {
+                    "AWS": {
+                      "Fn::GetAtt": [
+                        "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                        "Arn"
+                      ]
+                    }
+                  },
+                  "Resource": [
+                    {
+                      "Fn::GetAtt": [
+                        "bucket43879C71",
+                        "Arn"
+                      ]
+                    },
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          {
+                            "Fn::GetAtt": [
+                              "bucket43879C71",
+                              "Arn"
+                            ]
+                          },
+                          "/*"
+                        ]
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "Version": "2012-10-17"
+            }
+          },
+          "Metadata": {
+            "aws:cdk:path": "teststack/nesty/bucket/Policy/Resource"
+          }
+        },
+        "bucketAutoDeleteObjectsCustomResource3F4990B2": {
+          "Type": "Custom::S3AutoDeleteObjects",
+          "Properties": {
+            "ServiceToken": {
+              "Fn::GetAtt": [
+                "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+                "Arn"
+              ]
+            },
+            "BucketName": {
+              "Ref": "bucket43879C71"
+            }
+          },
+          "DependsOn": [
+            "bucketPolicy638F945D"
+          ],
+          "UpdateReplacePolicy": "Delete",
+          "DeletionPolicy": "Delete",
+          "Metadata": {
+            "aws:cdk:path": "teststack/nesty/bucket/AutoDeleteObjectsCustomResource/Default"
+          }
+        },
+        "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092": {
+          "Type": "AWS::IAM::Role",
+          "Properties": {
+            "AssumeRolePolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "sts:AssumeRole",
+                  "Effect": "Allow",
+                  "Principal": {
+                    "Service": "lambda.amazonaws.com"
+                  }
+                }
+              ]
+            },
+            "ManagedPolicyArns": [
+              {
+                "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+              }
+            ]
+          },
+          "Metadata": {
+            "aws:cdk:path": "teststack/nesty/Custom::S3AutoDeleteObjectsCustomResourceProvider/Role"
+          }
+        },
+        "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": {
+          "Type": "AWS::Lambda::Function",
+          "Properties": {
+            "Code": {
+              "S3Bucket": "DUMMY",
+              "S3Key": "DUMMY"
+            },
+            "Timeout": 900,
+            "MemorySize": 128,
+            "Handler": "index.handler",
+            "Role": {
+              "Fn::GetAtt": [
+                "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                "Arn"
+              ]
+            },
+            "Runtime": "nodejs20.x",
+            "Description": {
+              "Fn::Join": [
+                "",
+                [
+                  "Lambda function for auto-deleting objects in ",
+                  {
+                    "Ref": "bucket43879C71"
+                  },
+                  " S3 bucket."
+                ]
+              ]
+            }
+          },
+          "DependsOn": [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092"
+          ],
+          "Metadata": {
+            "aws:cdk:path": "teststack/nesty/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler",
+            "aws:asset:path": "asset.faa95a81ae7d7373f3e1f242268f904eb748d8d0fdd306e8a6fe515a1905a7d6",
+            "aws:asset:property": "Code"
+          }
+        }
+      },
+      "Parameters": {
+        "referencetoteststackbucket4A009163Ref": {
+          "Type": "String"
+        }
+      },
+      "Outputs": {
+        "teststacknestybucket3B9EFE19Ref": {
+          "Value": {
+            "Ref": "bucket43879C71"
+          }
+        },
+        "teststacknestybucket3B9EFE19Arn": {
+          "Value": {
+            "Fn::GetAtt": [
+              "bucket43879C71",
+              "Arn"
+            ]
+          }
+        }
+      },
+      "logicalId": "nestyNestedStacknestyNestedStackResource"
+    }
+  }
+}

--- a/tests/test-data/nested-stack/teststack.assets.json
+++ b/tests/test-data/nested-stack/teststack.assets.json
@@ -1,0 +1,84 @@
+{
+  "version": "36.3.0",
+  "files": {
+    "faa95a81ae7d7373f3e1f242268f904eb748d8d0fdd306e8a6fe515a1905a7d6": {
+      "source": {
+        "path": "asset.faa95a81ae7d7373f3e1f242268f904eb748d8d0fdd306e8a6fe515a1905a7d6",
+        "packaging": "zip"
+      },
+      "destinations": {
+        "616138583583-us-west-2": {
+          "bucketName": "pulumi-cdk-sted-sta-3ca1883d-staging",
+          "objectKey": "faa95a81ae7d7373f3e1f242268f904eb748d8d0fdd306e8a6fe515a1905a7d6.zip",
+          "region": "us-west-2"
+        }
+      }
+    },
+    "6620cb784ea0d3cf3a6e3e128827087f88e7e9999cd41b0be7c50431fbf12026": {
+      "source": {
+        "path": "asset.6620cb784ea0d3cf3a6e3e128827087f88e7e9999cd41b0be7c50431fbf12026.zip",
+        "packaging": "file"
+      },
+      "destinations": {
+        "616138583583-us-west-2": {
+          "bucketName": "pulumi-cdk-sted-sta-3ca1883d-staging",
+          "objectKey": "deploy-time/6620cb784ea0d3cf3a6e3e128827087f88e7e9999cd41b0be7c50431fbf12026.zip",
+          "region": "us-west-2"
+        }
+      }
+    },
+    "2d56e153cac88d3e0c2f842e8e6f6783b8725bf91f95e0673b4725448a56e96d": {
+      "source": {
+        "path": "asset.2d56e153cac88d3e0c2f842e8e6f6783b8725bf91f95e0673b4725448a56e96d",
+        "packaging": "zip"
+      },
+      "destinations": {
+        "616138583583-us-west-2": {
+          "bucketName": "pulumi-cdk-sted-sta-3ca1883d-staging",
+          "objectKey": "deploy-time/2d56e153cac88d3e0c2f842e8e6f6783b8725bf91f95e0673b4725448a56e96d.zip",
+          "region": "us-west-2"
+        }
+      }
+    },
+    "a386ba9b8c0d9b386083b2f6952db278a5a0ce88f497484eb5e62172219468fd": {
+      "source": {
+        "path": "asset.a386ba9b8c0d9b386083b2f6952db278a5a0ce88f497484eb5e62172219468fd",
+        "packaging": "zip"
+      },
+      "destinations": {
+        "616138583583-us-west-2": {
+          "bucketName": "pulumi-cdk-sted-sta-3ca1883d-staging",
+          "objectKey": "a386ba9b8c0d9b386083b2f6952db278a5a0ce88f497484eb5e62172219468fd.zip",
+          "region": "us-west-2"
+        }
+      }
+    },
+    "95f78991f9fb0b754d5d23113980217d0636f22d034b8f8bb451154a21d811a6": {
+      "source": {
+        "path": "teststacknesty613E34DC.nested.template.json",
+        "packaging": "file"
+      },
+      "destinations": {
+        "616138583583-us-west-2": {
+          "bucketName": "pulumi-cdk-sted-sta-3ca1883d-staging",
+          "objectKey": "95f78991f9fb0b754d5d23113980217d0636f22d034b8f8bb451154a21d811a6.json",
+          "region": "us-west-2"
+        }
+      }
+    },
+    "4cc5fad210e6468e30325de9b3f814b86a6bb8c61b9b5d7e8437c5290ab31f99": {
+      "source": {
+        "path": "teststack.template.json",
+        "packaging": "file"
+      },
+      "destinations": {
+        "616138583583-us-west-2": {
+          "bucketName": "pulumi-cdk-sted-sta-3ca1883d-staging",
+          "objectKey": "deploy-time/4cc5fad210e6468e30325de9b3f814b86a6bb8c61b9b5d7e8437c5290ab31f99.json",
+          "region": "us-west-2"
+        }
+      }
+    }
+  },
+  "dockerImages": {}
+}

--- a/tests/test-data/nested-stack/teststack.template.json
+++ b/tests/test-data/nested-stack/teststack.template.json
@@ -1,0 +1,297 @@
+{
+ "Resources": {
+  "bucket": {
+   "Type": "AWS::S3::Bucket",
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "teststack/bucket/Resource"
+   }
+  },
+  "nestyNestedStacknestyNestedStackResource": {
+   "Type": "AWS::CloudFormation::Stack",
+   "Properties": {
+    "Parameters": {
+     "referencetoteststackbucket4A009163Ref": {
+      "Ref": "bucket"
+     }
+    },
+    "TemplateURL": {
+     "Fn::Join": [
+      "",
+      [
+       "https://s3.us-west-2.",
+       {
+        "Ref": "AWS::URLSuffix"
+       },
+       "/",
+       {
+        "Ref": {
+         "PulumiOutput": 18
+        }
+       },
+       "/",
+       {
+        "Ref": {
+         "PulumiOutput": 19
+        }
+       }
+      ]
+     ]
+    }
+   },
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete",
+   "Metadata": {
+    "aws:cdk:path": "teststack/nesty.NestedStack/nesty.NestedStackResource",
+    "aws:asset:path": "teststacknesty613E34DC.nested.template.json",
+    "aws:asset:property": "TemplateURL"
+   }
+  },
+  "DeployWebsiteAwsCliLayer": {
+   "Type": "AWS::Lambda::LayerVersion",
+   "Properties": {
+    "Content": {
+     "S3Bucket": {
+      "Ref": {
+       "PulumiOutput": 6
+      }
+     },
+     "S3Key": {
+      "Ref": {
+       "PulumiOutput": 7
+      }
+     }
+    },
+    "Description": "/opt/awscli/aws"
+   },
+   "Metadata": {
+    "aws:cdk:path": "teststack/DeployWebsite/AwsCliLayer/Resource",
+    "aws:asset:path": "asset.6620cb784ea0d3cf3a6e3e128827087f88e7e9999cd41b0be7c50431fbf12026.zip",
+    "aws:asset:is-bundled": false,
+    "aws:asset:property": "Content"
+   }
+  },
+  "DeployWebsiteCustomResource": {
+   "Type": "Custom::CDKBucketDeployment",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C",
+      "Arn"
+     ]
+    },
+    "SourceBucketNames": [
+     {
+      "Ref": {
+       "PulumiOutput": 14
+      }
+     }
+    ],
+    "SourceObjectKeys": [
+     {
+      "Ref": {
+       "PulumiOutput": 15
+      }
+     }
+    ],
+    "SourceMarkers": [
+     {}
+    ],
+    "DestinationBucketName": {
+     "Fn::GetAtt": [
+      "nestyNestedStacknestyNestedStackResource",
+      "Outputs.teststacknestybucket3B9EFE19Ref"
+     ]
+    },
+    "Prune": true
+   },
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete",
+   "Metadata": {
+    "aws:cdk:path": "teststack/DeployWebsite/CustomResource/Default"
+   }
+  },
+  "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole/Resource"
+   }
+  },
+  "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "s3:GetObject*",
+        "s3:GetBucket*",
+        "s3:List*"
+       ],
+       "Effect": "Allow",
+       "Resource": [
+        {
+         "Fn::Join": [
+          "",
+          [
+           "arn:",
+           {
+            "Ref": "AWS::Partition"
+           },
+           ":s3:::",
+           {
+            "Ref": {
+             "PulumiOutput": 14
+            }
+           }
+          ]
+         ]
+        },
+        {
+         "Fn::Join": [
+          "",
+          [
+           "arn:",
+           {
+            "Ref": "AWS::Partition"
+           },
+           ":s3:::",
+           {
+            "Ref": {
+             "PulumiOutput": 14
+            }
+           },
+           "/*"
+          ]
+         ]
+        }
+       ]
+      },
+      {
+       "Action": [
+        "s3:GetObject*",
+        "s3:GetBucket*",
+        "s3:List*",
+        "s3:DeleteObject*",
+        "s3:PutObject",
+        "s3:PutObjectLegalHold",
+        "s3:PutObjectRetention",
+        "s3:PutObjectTagging",
+        "s3:PutObjectVersionTagging",
+        "s3:Abort*"
+       ],
+       "Effect": "Allow",
+       "Resource": [
+        {
+         "Fn::GetAtt": [
+          "nestyNestedStacknestyNestedStackResource",
+          "Outputs.teststacknestybucket3B9EFE19Arn"
+         ]
+        },
+        {
+         "Fn::Join": [
+          "",
+          [
+           {
+            "Fn::GetAtt": [
+             "nestyNestedStacknestyNestedStackResource",
+             "Outputs.teststacknestybucket3B9EFE19Arn"
+            ]
+           },
+           "/*"
+          ]
+         ]
+        }
+       ]
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy",
+    "Roles": [
+     {
+      "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole"
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole/DefaultPolicy/Resource"
+   }
+  },
+  "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": {
+      "Ref": {
+       "PulumiOutput": 10
+      }
+     },
+     "S3Key": {
+      "Ref": {
+       "PulumiOutput": 11
+      }
+     }
+    },
+    "Environment": {
+     "Variables": {
+      "AWS_CA_BUNDLE": "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+     }
+    },
+    "Handler": "index.handler",
+    "Layers": [
+     {
+      "Ref": "DeployWebsiteAwsCliLayer"
+     }
+    ],
+    "Role": {
+     "Fn::GetAtt": [
+      "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole",
+      "Arn"
+     ]
+    },
+    "Runtime": "python3.9",
+    "Timeout": 900
+   },
+   "DependsOn": [
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy",
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/Resource",
+    "aws:asset:path": "asset.2d56e153cac88d3e0c2f842e8e6f6783b8725bf91f95e0673b4725448a56e96d",
+    "aws:asset:is-bundled": false,
+    "aws:asset:property": "Code"
+   }
+  }
+ }
+}

--- a/tests/test-data/nested-stack/teststacknesty613E34DC.nested.template.json
+++ b/tests/test-data/nested-stack/teststacknesty613E34DC.nested.template.json
@@ -1,0 +1,234 @@
+{
+ "Resources": {
+  "bucket43879C71": {
+   "Type": "AWS::S3::Bucket",
+   "Properties": {
+    "BucketName": {
+     "Fn::Join": [
+      "",
+      [
+       {
+        "Ref": "referencetoteststackbucket4A009163Ref"
+       },
+       "-nested"
+      ]
+     ]
+    },
+    "PublicAccessBlockConfiguration": {
+     "BlockPublicAcls": false,
+     "BlockPublicPolicy": false,
+     "IgnorePublicAcls": false,
+     "RestrictPublicBuckets": false
+    },
+    "Tags": [
+     {
+      "Key": "aws-cdk:auto-delete-objects",
+      "Value": "true"
+     },
+     {
+      "Key": "aws-cdk:cr-owned:043cc088",
+      "Value": "true"
+     }
+    ],
+    "WebsiteConfiguration": {
+     "IndexDocument": "index.html"
+    }
+   },
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete",
+   "Metadata": {
+    "aws:cdk:path": "teststack/nesty/bucket/Resource"
+   }
+  },
+  "bucketPolicy638F945D": {
+   "Type": "AWS::S3::BucketPolicy",
+   "Properties": {
+    "Bucket": {
+     "Ref": "bucket43879C71"
+    },
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": "s3:GetObject",
+       "Effect": "Allow",
+       "Principal": {
+        "AWS": "*"
+       },
+       "Resource": {
+        "Fn::Join": [
+         "",
+         [
+          {
+           "Fn::GetAtt": [
+            "bucket43879C71",
+            "Arn"
+           ]
+          },
+          "/*"
+         ]
+        ]
+       }
+      },
+      {
+       "Action": [
+        "s3:PutBucketPolicy",
+        "s3:GetBucket*",
+        "s3:List*",
+        "s3:DeleteObject*"
+       ],
+       "Effect": "Allow",
+       "Principal": {
+        "AWS": {
+         "Fn::GetAtt": [
+          "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+          "Arn"
+         ]
+        }
+       },
+       "Resource": [
+        {
+         "Fn::GetAtt": [
+          "bucket43879C71",
+          "Arn"
+         ]
+        },
+        {
+         "Fn::Join": [
+          "",
+          [
+           {
+            "Fn::GetAtt": [
+             "bucket43879C71",
+             "Arn"
+            ]
+           },
+           "/*"
+          ]
+         ]
+        }
+       ]
+      }
+     ],
+     "Version": "2012-10-17"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "teststack/nesty/bucket/Policy/Resource"
+   }
+  },
+  "bucketAutoDeleteObjectsCustomResource3F4990B2": {
+   "Type": "Custom::S3AutoDeleteObjects",
+   "Properties": {
+    "ServiceToken": {
+     "Fn::GetAtt": [
+      "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+      "Arn"
+     ]
+    },
+    "BucketName": {
+     "Ref": "bucket43879C71"
+    }
+   },
+   "DependsOn": [
+    "bucketPolicy638F945D"
+   ],
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete",
+   "Metadata": {
+    "aws:cdk:path": "teststack/nesty/bucket/AutoDeleteObjectsCustomResource/Default"
+   }
+  },
+  "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Version": "2012-10-17",
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ]
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "teststack/nesty/Custom::S3AutoDeleteObjectsCustomResourceProvider/Role"
+   }
+  },
+  "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": {
+      "Ref": {
+       "PulumiOutput": 2
+      }
+     },
+     "S3Key": {
+      "Ref": {
+       "PulumiOutput": 3
+      }
+     }
+    },
+    "Timeout": 900,
+    "MemorySize": 128,
+    "Handler": "index.handler",
+    "Role": {
+     "Fn::GetAtt": [
+      "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+      "Arn"
+     ]
+    },
+    "Runtime": "nodejs20.x",
+    "Description": {
+     "Fn::Join": [
+      "",
+      [
+       "Lambda function for auto-deleting objects in ",
+       {
+        "Ref": "bucket43879C71"
+       },
+       " S3 bucket."
+      ]
+     ]
+    }
+   },
+   "DependsOn": [
+    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "teststack/nesty/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler",
+    "aws:asset:path": "asset.faa95a81ae7d7373f3e1f242268f904eb748d8d0fdd306e8a6fe515a1905a7d6",
+    "aws:asset:property": "Code"
+   }
+  }
+ },
+ "Parameters": {
+  "referencetoteststackbucket4A009163Ref": {
+   "Type": "String"
+  }
+ },
+ "Outputs": {
+  "teststacknestybucket3B9EFE19Ref": {
+   "Value": {
+    "Ref": "bucket43879C71"
+   }
+  },
+  "teststacknestybucket3B9EFE19Arn": {
+   "Value": {
+    "Fn::GetAtt": [
+     "bucket43879C71",
+     "Arn"
+    ]
+   }
+  }
+ }
+}

--- a/tests/test-data/nested-stack/tree.json
+++ b/tests/test-data/nested-stack/tree.json
@@ -1,0 +1,711 @@
+{
+  "version": "tree-0.1",
+  "tree": {
+    "id": "App",
+    "path": "",
+    "children": {
+      "teststack": {
+        "id": "teststack",
+        "path": "teststack",
+        "children": {
+          "bucket": {
+            "id": "bucket",
+            "path": "teststack/bucket",
+            "children": {
+              "Resource": {
+                "id": "Resource",
+                "path": "teststack/bucket/Resource",
+                "attributes": {
+                  "aws:cdk:cloudformation:type": "AWS::S3::Bucket",
+                  "aws:cdk:cloudformation:props": {}
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
+                  "version": "2.149.0"
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.aws_s3.Bucket",
+              "version": "2.149.0"
+            }
+          },
+          "nesty": {
+            "id": "nesty",
+            "path": "teststack/nesty",
+            "children": {
+              "bucket": {
+                "id": "bucket",
+                "path": "teststack/nesty/bucket",
+                "children": {
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "teststack/nesty/bucket/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::S3::Bucket",
+                      "aws:cdk:cloudformation:props": {
+                        "bucketName": {
+                          "Fn::Join": [
+                            "",
+                            [
+                              {
+                                "Ref": "referencetoteststackbucket4A009163Ref"
+                              },
+                              "-nested"
+                            ]
+                          ]
+                        },
+                        "publicAccessBlockConfiguration": {
+                          "blockPublicAcls": false,
+                          "blockPublicPolicy": false,
+                          "ignorePublicAcls": false,
+                          "restrictPublicBuckets": false
+                        },
+                        "tags": [
+                          {
+                            "key": "aws-cdk:auto-delete-objects",
+                            "value": "true"
+                          },
+                          {
+                            "key": "aws-cdk:cr-owned:043cc088",
+                            "value": "true"
+                          }
+                        ],
+                        "websiteConfiguration": {
+                          "indexDocument": "index.html"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_s3.CfnBucket",
+                      "version": "2.149.0"
+                    }
+                  },
+                  "Policy": {
+                    "id": "Policy",
+                    "path": "teststack/nesty/bucket/Policy",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "teststack/nesty/bucket/Policy/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::S3::BucketPolicy",
+                          "aws:cdk:cloudformation:props": {
+                            "bucket": {
+                              "Ref": "bucket43879C71"
+                            },
+                            "policyDocument": {
+                              "Statement": [
+                                {
+                                  "Action": "s3:GetObject",
+                                  "Effect": "Allow",
+                                  "Principal": {
+                                    "AWS": "*"
+                                  },
+                                  "Resource": {
+                                    "Fn::Join": [
+                                      "",
+                                      [
+                                        {
+                                          "Fn::GetAtt": [
+                                            "bucket43879C71",
+                                            "Arn"
+                                          ]
+                                        },
+                                        "/*"
+                                      ]
+                                    ]
+                                  }
+                                },
+                                {
+                                  "Action": [
+                                    "s3:PutBucketPolicy",
+                                    "s3:GetBucket*",
+                                    "s3:List*",
+                                    "s3:DeleteObject*"
+                                  ],
+                                  "Effect": "Allow",
+                                  "Principal": {
+                                    "AWS": {
+                                      "Fn::GetAtt": [
+                                        "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                                        "Arn"
+                                      ]
+                                    }
+                                  },
+                                  "Resource": [
+                                    {
+                                      "Fn::GetAtt": [
+                                        "bucket43879C71",
+                                        "Arn"
+                                      ]
+                                    },
+                                    {
+                                      "Fn::Join": [
+                                        "",
+                                        [
+                                          {
+                                            "Fn::GetAtt": [
+                                              "bucket43879C71",
+                                              "Arn"
+                                            ]
+                                          },
+                                          "/*"
+                                        ]
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Version": "2012-10-17"
+                            }
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_s3.CfnBucketPolicy",
+                          "version": "2.149.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_s3.BucketPolicy",
+                      "version": "2.149.0"
+                    }
+                  },
+                  "AutoDeleteObjectsCustomResource": {
+                    "id": "AutoDeleteObjectsCustomResource",
+                    "path": "teststack/nesty/bucket/AutoDeleteObjectsCustomResource",
+                    "children": {
+                      "Default": {
+                        "id": "Default",
+                        "path": "teststack/nesty/bucket/AutoDeleteObjectsCustomResource/Default",
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.CfnResource",
+                          "version": "2.149.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.CustomResource",
+                      "version": "2.149.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_s3.Bucket",
+                  "version": "2.149.0"
+                }
+              },
+              "Custom::S3AutoDeleteObjectsCustomResourceProvider": {
+                "id": "Custom::S3AutoDeleteObjectsCustomResourceProvider",
+                "path": "teststack/nesty/Custom::S3AutoDeleteObjectsCustomResourceProvider",
+                "children": {
+                  "Staging": {
+                    "id": "Staging",
+                    "path": "teststack/nesty/Custom::S3AutoDeleteObjectsCustomResourceProvider/Staging",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.AssetStaging",
+                      "version": "2.149.0"
+                    }
+                  },
+                  "Role": {
+                    "id": "Role",
+                    "path": "teststack/nesty/Custom::S3AutoDeleteObjectsCustomResourceProvider/Role",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.CfnResource",
+                      "version": "2.149.0"
+                    }
+                  },
+                  "Handler": {
+                    "id": "Handler",
+                    "path": "teststack/nesty/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.CfnResource",
+                      "version": "2.149.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.CustomResourceProviderBase",
+                  "version": "2.149.0"
+                }
+              },
+              "reference-to-teststackbucket4A009163Ref": {
+                "id": "reference-to-teststackbucket4A009163Ref",
+                "path": "teststack/nesty/reference-to-teststackbucket4A009163Ref",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.CfnParameter",
+                  "version": "2.156.0"
+                }
+              },
+              "teststacknestybucket3B9EFE19Ref": {
+                "id": "teststacknestybucket3B9EFE19Ref",
+                "path": "teststack/nesty/teststacknestybucket3B9EFE19Ref",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.CfnOutput",
+                  "version": "2.156.0"
+                }
+              },
+              "teststacknestybucket3B9EFE19Arn": {
+                "id": "teststacknestybucket3B9EFE19Arn",
+                "path": "teststack/nesty/teststacknestybucket3B9EFE19Arn",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.CfnOutput",
+                  "version": "2.156.0"
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.NestedStack",
+              "version": "2.149.0"
+            }
+          },
+          "nesty.NestedStack": {
+            "id": "nesty.NestedStack",
+            "path": "teststack/nesty.NestedStack",
+            "children": {
+              "nesty.NestedStackResource": {
+                "id": "nesty.NestedStackResource",
+                "path": "teststack/nesty.NestedStack/nesty.NestedStackResource",
+                "attributes": {
+                  "aws:cdk:cloudformation:type": "AWS::CloudFormation::Stack",
+                  "aws:cdk:cloudformation:props": {
+                    "parameters": {
+                      "referencetoteststackbucket4A009163Ref": {
+                        "Ref": "bucket"
+                      }
+                    },
+                    "templateUrl": {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "https://s3.us-west-2.",
+                          {
+                            "Ref": "AWS::URLSuffix"
+                          },
+                          "/",
+                          {
+                            "Ref": {
+                              "PulumiOutput": 18
+                            }
+                          },
+                          "/",
+                          {
+                            "Ref": {
+                              "PulumiOutput": 19
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.CfnStack",
+                  "version": "2.149.0"
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "constructs.Construct",
+              "version": "10.3.0"
+            }
+          },
+          "DeployWebsite": {
+            "id": "DeployWebsite",
+            "path": "teststack/DeployWebsite",
+            "children": {
+              "AwsCliLayer": {
+                "id": "AwsCliLayer",
+                "path": "teststack/DeployWebsite/AwsCliLayer",
+                "children": {
+                  "Code": {
+                    "id": "Code",
+                    "path": "teststack/DeployWebsite/AwsCliLayer/Code",
+                    "children": {
+                      "Stage": {
+                        "id": "Stage",
+                        "path": "teststack/DeployWebsite/AwsCliLayer/Code/Stage",
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.AssetStaging",
+                          "version": "2.149.0"
+                        }
+                      },
+                      "AssetBucket": {
+                        "id": "AssetBucket",
+                        "path": "teststack/DeployWebsite/AwsCliLayer/Code/AssetBucket",
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_s3.BucketBase",
+                          "version": "2.149.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
+                      "version": "2.149.0"
+                    }
+                  },
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "teststack/DeployWebsite/AwsCliLayer/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::Lambda::LayerVersion",
+                      "aws:cdk:cloudformation:props": {
+                        "content": {
+                          "s3Bucket": {
+                            "Ref": {
+                              "PulumiOutput": 6
+                            }
+                          },
+                          "s3Key": {
+                            "Ref": {
+                              "PulumiOutput": 7
+                            }
+                          }
+                        },
+                        "description": "/opt/awscli/aws"
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_lambda.CfnLayerVersion",
+                      "version": "2.149.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.lambda_layer_awscli.AwsCliLayer",
+                  "version": "2.149.0"
+                }
+              },
+              "CustomResourceHandler": {
+                "id": "CustomResourceHandler",
+                "path": "teststack/DeployWebsite/CustomResourceHandler",
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_lambda.SingletonFunction",
+                  "version": "2.149.0"
+                }
+              },
+              "Asset1": {
+                "id": "Asset1",
+                "path": "teststack/DeployWebsite/Asset1",
+                "children": {
+                  "Stage": {
+                    "id": "Stage",
+                    "path": "teststack/DeployWebsite/Asset1/Stage",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.AssetStaging",
+                      "version": "2.149.0"
+                    }
+                  },
+                  "AssetBucket": {
+                    "id": "AssetBucket",
+                    "path": "teststack/DeployWebsite/Asset1/AssetBucket",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_s3.BucketBase",
+                      "version": "2.149.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
+                  "version": "2.149.0"
+                }
+              },
+              "CustomResource": {
+                "id": "CustomResource",
+                "path": "teststack/DeployWebsite/CustomResource",
+                "children": {
+                  "Default": {
+                    "id": "Default",
+                    "path": "teststack/DeployWebsite/CustomResource/Default",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.CfnResource",
+                      "version": "2.149.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.CustomResource",
+                  "version": "2.149.0"
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.aws_s3_deployment.BucketDeployment",
+              "version": "2.149.0"
+            }
+          },
+          "Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C": {
+            "id": "Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C",
+            "path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C",
+            "children": {
+              "ServiceRole": {
+                "id": "ServiceRole",
+                "path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole",
+                "children": {
+                  "ImportServiceRole": {
+                    "id": "ImportServiceRole",
+                    "path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole/ImportServiceRole",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.Resource",
+                      "version": "2.149.0"
+                    }
+                  },
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                      "aws:cdk:cloudformation:props": {
+                        "assumeRolePolicyDocument": {
+                          "Statement": [
+                            {
+                              "Action": "sts:AssumeRole",
+                              "Effect": "Allow",
+                              "Principal": {
+                                "Service": "lambda.amazonaws.com"
+                              }
+                            }
+                          ],
+                          "Version": "2012-10-17"
+                        },
+                        "managedPolicyArns": [
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                "arn:",
+                                {
+                                  "Ref": "AWS::Partition"
+                                },
+                                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+                              ]
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                      "version": "2.149.0"
+                    }
+                  },
+                  "DefaultPolicy": {
+                    "id": "DefaultPolicy",
+                    "path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole/DefaultPolicy",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/ServiceRole/DefaultPolicy/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::IAM::Policy",
+                          "aws:cdk:cloudformation:props": {
+                            "policyDocument": {
+                              "Statement": [
+                                {
+                                  "Action": [
+                                    "s3:GetObject*",
+                                    "s3:GetBucket*",
+                                    "s3:List*"
+                                  ],
+                                  "Effect": "Allow",
+                                  "Resource": [
+                                    {
+                                      "Fn::Join": [
+                                        "",
+                                        [
+                                          "arn:",
+                                          {
+                                            "Ref": "AWS::Partition"
+                                          },
+                                          ":s3:::",
+                                          {
+                                            "Ref": {
+                                              "PulumiOutput": 14
+                                            }
+                                          }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "Fn::Join": [
+                                        "",
+                                        [
+                                          "arn:",
+                                          {
+                                            "Ref": "AWS::Partition"
+                                          },
+                                          ":s3:::",
+                                          {
+                                            "Ref": {
+                                              "PulumiOutput": 14
+                                            }
+                                          },
+                                          "/*"
+                                        ]
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Action": [
+                                    "s3:GetObject*",
+                                    "s3:GetBucket*",
+                                    "s3:List*",
+                                    "s3:DeleteObject*",
+                                    "s3:PutObject",
+                                    "s3:PutObjectLegalHold",
+                                    "s3:PutObjectRetention",
+                                    "s3:PutObjectTagging",
+                                    "s3:PutObjectVersionTagging",
+                                    "s3:Abort*"
+                                  ],
+                                  "Effect": "Allow",
+                                  "Resource": [
+                                    {
+                                      "Fn::GetAtt": [
+                                        "nestyNestedStacknestyNestedStackResource",
+                                        "Outputs.teststacknestybucket3B9EFE19Arn"
+                                      ]
+                                    },
+                                    {
+                                      "Fn::Join": [
+                                        "",
+                                        [
+                                          {
+                                            "Fn::GetAtt": [
+                                              "nestyNestedStacknestyNestedStackResource",
+                                              "Outputs.teststacknestybucket3B9EFE19Arn"
+                                            ]
+                                          },
+                                          "/*"
+                                        ]
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Version": "2012-10-17"
+                            },
+                            "policyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy",
+                            "roles": [
+                              {
+                                "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole"
+                              }
+                            ]
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
+                          "version": "2.149.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.Policy",
+                      "version": "2.149.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_iam.Role",
+                  "version": "2.149.0"
+                }
+              },
+              "Code": {
+                "id": "Code",
+                "path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/Code",
+                "children": {
+                  "Stage": {
+                    "id": "Stage",
+                    "path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/Code/Stage",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.AssetStaging",
+                      "version": "2.149.0"
+                    }
+                  },
+                  "AssetBucket": {
+                    "id": "AssetBucket",
+                    "path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/Code/AssetBucket",
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_s3.BucketBase",
+                      "version": "2.149.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_s3_assets.Asset",
+                  "version": "2.149.0"
+                }
+              },
+              "Resource": {
+                "id": "Resource",
+                "path": "teststack/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C/Resource",
+                "attributes": {
+                  "aws:cdk:cloudformation:type": "AWS::Lambda::Function",
+                  "aws:cdk:cloudformation:props": {
+                    "code": {
+                      "s3Bucket": {
+                        "Ref": {
+                          "PulumiOutput": 10
+                        }
+                      },
+                      "s3Key": {
+                        "Ref": {
+                          "PulumiOutput": 11
+                        }
+                      }
+                    },
+                    "environment": {
+                      "variables": {
+                        "AWS_CA_BUNDLE": "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+                      }
+                    },
+                    "handler": "index.handler",
+                    "layers": [
+                      {
+                        "Ref": "DeployWebsiteAwsCliLayer"
+                      }
+                    ],
+                    "role": {
+                      "Fn::GetAtt": [
+                        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole",
+                        "Arn"
+                      ]
+                    },
+                    "runtime": "python3.9",
+                    "timeout": 900
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_lambda.CfnFunction",
+                  "version": "2.149.0"
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.aws_lambda.Function",
+              "version": "2.149.0"
+            }
+          }
+        },
+        "constructInfo": {
+          "fqn": "aws-cdk-lib.Stack",
+          "version": "2.156.0"
+        }
+      },
+      "Tree": {
+        "id": "Tree",
+        "path": "Tree",
+        "constructInfo": {
+          "fqn": "constructs.Construct",
+          "version": "10.3.0"
+        }
+      }
+    },
+    "constructInfo": {
+      "fqn": "aws-cdk-lib.App",
+      "version": "2.156.0"
+    }
+  }
+}

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -14,8 +14,8 @@ export function createStackManifest(props: CreateStackManifestProps): StackManif
         id: 'stack',
         templatePath: 'template',
         metadata: {
-            'stack/resource-1': 'resource1',
-            'stack/resource-2': 'resource2',
+            'stack/resource-1': { stackPath: 'stack', id: 'resource1' },
+            'stack/resource-2': { stackPath: 'stack', id: 'resource2' },
         },
         tree: {
             path: 'stack',
@@ -37,6 +37,7 @@ export function createStackManifest(props: CreateStackManifestProps): StackManif
                 },
             },
         },
+        nestedStacks: {},
         template: {
             Mappings: props.mappings,
             Resources: {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -59,3 +59,245 @@ export function createStackManifest(props: CreateStackManifestProps): StackManif
         dependencies: [],
     });
 }
+
+export interface NestedStackManifestProps {
+    nestedResourceProps?: any;
+    outputResourceProps?: any;
+    nestedStackResourceProps?: any;
+    nestedStackOutputs?: any;
+    nestedStackProperties?: any;
+    nestedStackParameters?: any;
+}
+
+export function createNestedStackManifest(props: NestedStackManifestProps): StackManifest {
+    return new StackManifest({
+        id: 'stack',
+        templatePath: 'test/stack',
+        metadata: {
+            'stack/example-bucket/Resource': { stackPath: 'stack', id: 'parent' },
+            'stack/example-bucket/Policy/Resource': { stackPath: 'stack', id: 'parentPolicy' },
+            'stack/nested.NestedStack/nested.NestedStackResource': { stackPath: 'stack', id: 'nested.NestedStackResource' },
+            'stack/nested/example-bucket/Resource': { stackPath: 'stack/nested', id: 'child' },
+            'stack/nested/example-bucket/Policy/Resource': { stackPath: 'stack/nested', id: 'childPolicy' },
+            'stack/output-bucket/Resource': { stackPath: 'stack', id: 'output' },
+            'stack/output-bucket/Policy/Resource': { stackPath: 'stack', id: 'outputPolicy' },
+        },
+        nestedStacks: {
+            'stack/nested': {
+                logicalId: 'nested.NestedStack',
+                Resources: {
+                    child: {
+                        Type: 'AWS::S3::Bucket',
+                        Properties: props.nestedResourceProps,
+                    },
+                    childPolicy: {
+                        Type: 'AWS::S3::BucketPolicy',
+                        Properties: {
+                            Bucket: {
+                                Ref: 'child',
+                            },
+                        },
+                    },
+                },
+                Outputs: props.nestedStackOutputs,
+                Parameters: props.nestedStackParameters,
+            },
+        },
+        tree: {
+            path: 'stack',
+            id: 'stack',
+            children: {
+                'example-bucket': {
+                    id: 'example-bucket',
+                    path: 'stack/example-bucket',
+                    constructInfo: {
+                        fqn: 'aws-cdk-lib.aws_s3.Bucket',
+                        version: '2.149.0',
+                    },
+                    children: {
+                        Resource: {
+                            id: 'Resource',
+                            path: 'stack/example-bucket/Resource',
+                            attributes: {
+                                'aws:cdk:cloudformation:type': 'AWS::S3::Bucket',
+                            },
+                            constructInfo: {
+                                fqn: 'aws-cdk-lib.aws_s3.CfnBucket',
+                                version: '2.149.0',
+                            },
+                        },
+                        Policy: {
+                            id: 'Policy',
+                            path: 'stack/example-bucket/Policy',
+                            children: {
+                                Resource: {
+                                    id: 'Resource',
+                                    path: 'stack/example-bucket/Policy/Resource',
+                                    attributes: {
+                                        'aws:cdk:cloudformation:type': 'AWS::S3::BucketPolicy',
+                                    },
+                                    constructInfo: {
+                                        fqn: 'aws-cdk-lib.aws_s3.CfnBucketPolicy',
+                                        version: '2.149.0',
+                                    },
+                                },
+                            },
+                            constructInfo: {
+                                fqn: 'aws-cdk-lib.aws_s3.BucketPolicy',
+                                version: '2.149.0',
+                            },
+                        },
+                    },
+                },
+                nested: {
+                    id: 'nested',
+                    path: 'stack/nested',
+                    children: {
+                        'example-bucket': {
+                            id: 'example-bucket',
+                            path: 'stack/nested/example-bucket',
+                            constructInfo: {
+                                fqn: 'aws-cdk-lib.aws_s3.Bucket',
+                                version: '2.149.0',
+                            },
+                            children: {
+                                Resource: {
+                                    id: 'Resource',
+                                    path: 'stack/nested/example-bucket/Resource',
+                                    attributes: {
+                                        'aws:cdk:cloudformation:type': 'AWS::S3::Bucket',
+                                    },
+                                    constructInfo: {
+                                        fqn: 'aws-cdk-lib.aws_s3.CfnBucket',
+                                        version: '2.149.0',
+                                    },
+                                },
+                                Policy: {
+                                    id: 'Policy',
+                                    path: 'stack/nested/example-bucket/Policy',
+                                    children: {
+                                        Resource: {
+                                            id: 'Resource',
+                                            path: 'stack/nested/example-bucket/Policy/Resource',
+                                            attributes: {
+                                                'aws:cdk:cloudformation:type': 'AWS::S3::BucketPolicy',
+                                            },
+                                            constructInfo: {
+                                                fqn: 'aws-cdk-lib.aws_s3.CfnBucketPolicy',
+                                                version: '2.149.0',
+                                            },
+                                        },
+                                    },
+                                    constructInfo: {
+                                        fqn: 'aws-cdk-lib.aws_s3.BucketPolicy',
+                                        version: '2.149.0',
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    constructInfo: {
+                        fqn: 'aws-cdk-lib.NestedStack',
+                        version: '2.149.0',
+                    },
+                },
+                "nested.NestedStack": {
+                    id: 'nested.NestedStack',
+                    path: 'stack/nested.NestedStack',
+                    children: {
+                        'nested.NestedStackResource': {
+                            id: 'nested.NestedStackResource',
+                            path: 'stack/nested.NestedStack/nested.NestedStackResource',
+                            attributes: {
+                                'aws:cdk:cloudformation:type': 'AWS::CloudFormation::Stack',
+                            },
+                            constructInfo: {
+                                fqn: 'aws-cdk-lib.CfnStack',
+                                version: '2.149.0',
+                            },
+                        },
+                    }
+                },
+                'output-bucket': {
+                    id: 'output-bucket',
+                    path: 'stack/output-bucket',
+                    constructInfo: {
+                        fqn: 'aws-cdk-lib.aws_s3.Bucket',
+                        version: '2.149.0',
+                    },
+                    children: {
+                        Resource: {
+                            id: 'Resource',
+                            path: 'stack/output-bucket/Resource',
+                            attributes: {
+                                'aws:cdk:cloudformation:type': 'AWS::S3::Bucket',
+                            },
+                            constructInfo: {
+                                fqn: 'aws-cdk-lib.aws_s3.CfnBucket',
+                                version: '2.149.0',
+                            },
+                        },
+                        Policy: {
+                            id: 'Policy',
+                            path: 'stack/output-bucket/Policy',
+                            children: {
+                                Resource: {
+                                    id: 'Resource',
+                                    path: 'stack/output-bucket/Policy/Resource',
+                                    attributes: {
+                                        'aws:cdk:cloudformation:type': 'AWS::S3::BucketPolicy',
+                                    },
+                                    constructInfo: {
+                                        fqn: 'aws-cdk-lib.aws_s3.CfnBucketPolicy',
+                                        version: '2.149.0',
+                                    },
+                                },
+                            },
+                            constructInfo: {
+                                fqn: 'aws-cdk-lib.aws_s3.BucketPolicy',
+                                version: '2.149.0',
+                            },
+                        },
+                    },
+                },
+            },
+            constructInfo: {
+                fqn: 'aws-cdk-lib.Stack',
+                version: '2.149.0',
+            },
+        },
+        template: {
+            Resources: {
+                parent: {
+                    Type: 'AWS::S3::Bucket',
+                    Properties: {},
+                },
+                parentPolicy: {
+                    Type: 'AWS::S3::BucketPolicy',
+                    Properties: {
+                        Bucket: {
+                            Ref: 'parent',
+                        },
+                    },
+                },
+                "nested.NestedStackResource": {
+                    Type: 'AWS::CloudFormation::Stack',
+                    Properties: props.nestedStackResourceProps,
+                },
+                output: {
+                    Type: 'AWS::S3::Bucket',
+                    Properties: props.outputResourceProps
+                },
+                outputPolicy: {
+                    Type: 'AWS::S3::BucketPolicy',
+                    Properties: {
+                        Bucket: {
+                            Ref: 'output',
+                        },
+                    },
+                },
+            },
+        },
+        dependencies: [],
+    });
+}


### PR DESCRIPTION
This change adds support for Nested Stacks to `pulumi-cdk`.
In CDK, a nested stack is a CDK stack that you create inside another stack, known as the parent stack. Users create nested stacks using the [NestedStack](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.NestedStack.html) construct.
By using nested stacks, users can organize resources across multiple stacks. Nested stacks also offer a way around the AWS CloudFormation 500-resource limit for stacks. A nested stack counts as only one resource in the stack that contains it. However, it can contain up to 500 resources, including additional nested stacks.
While Pulumi doesn't have those limitations, many existing CDK constructs use nested stacks to get around the CloudFormation limitations. The EKS cluster construct is one of the most prominent ones that require nested stacks.

In detail, this change:
- enhances the `AssemblyManifestReader` to support reading nested stacks.
- introduces a new unique `StackAddress` for elements in the CloudFormation templates. It combines the stack path (tree path of the stack) and the stack-local logical ID in order to form an assembly wide unique address. This is necessary in order to represent a hierarchy of stacks in the same pulumi program
- adds a new `NestedStackConstruct` component. It is used to namespace the resources of a NestedStack in order to not run into any issues with duplicate logical IDs. It achieves this by including the stack path in the pulumi resource type. The types of parent resources are included in URNs, meaning all resources parented under the nested stack have their own unique namespace.
- updates the artifact converter and intrinsics to handle cross stack references (Parameters & Outputs) for nested stacks

Integration tests and an example are part of https://github.com/pulumi/pulumi-cdk/pull/298 which is part of this PR stack.

### Review Advice
I'd recommend first reviewing the changes to the code reading the cloud assembly (`src/assembly/manifest.ts`), then the GraphBuilder (`src/graph.ts`) and lastly the app converter and intrinsics (`src/converters/app-converter.ts` & `src/converters/intrinsics.ts`). The other changes are in support for those

Fixes https://github.com/pulumi/pulumi-cdk/issues/80
