### PR TITLE
chore: add github release to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,12 @@ jobs:
           access: "public"
           token: ${{ secrets.NPM_TOKEN }}
           package: ${{github.workspace}}/package.json
+      - name: Create GH Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 name: release
 "on":
   push:


### PR DESCRIPTION
We were creating the tag, but not creating a GitHub release.