### PR TITLE
chore: add concurrency group to release job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,9 @@ jobs:
     needs:
       - build
       - lint
+    concurrency:
+      group: release
+      cancel-in-progress: false
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
 
   release:
     name: Release
+    concurrency:
+      group: release
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     needs:
       - build


### PR DESCRIPTION
This adds a concurrency group to the release workflow so only 1 release
will occur at a time

fixes #284