### PR TITLE
Fix renovate config to recognize @aws-cdk/cli-lib-alpha versions

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -23,6 +23,12 @@
       matchDataSource: ["npm"],
       matchPackageNames: ["@aws-cdk/cli-lib-alpha"],
       matchDepTypes: ["dependencies"],
+      // renovate can't handle the alpha versioning scheme (it expects major.minor.patch to always be the same)
+      // In this case it is the `-alpha.0` that always stays the same
+      // Here we tell renovate how to read the versioning. The important part
+      // is that we switch the `-alpha.0` to be the `compatibility` part instead of `prerelease`
+      // see https://docs.renovatebot.com/modules/versioning/regex/
+      versioning: "regex:^(?<major>\\d+)\\.((?<minor>\\d+))\\.((?<patch>\\d+))-(?<compatibility>.*)$",
     },
   ]
 }


### PR DESCRIPTION
Renovate can't handle the alpha versioning scheme used by `@aws-cdk-cli-lib-alpha`
When given `^2.178.1-alpha.0` it reads the `-alpha.0` as a `prerelease`
which means it marks the update as "unstable". For "unstable" updates
renovate only recognizes bumps to the `prerelease` portion, so it would
recognize `2.178.1-alpha.2`, but not `2.179.0-alpha.0`.
(it expects major.minor.patch to always be the same)

To handle this, we tell renovate how to read the versioning. The important part
is that we switch the `-alpha.0` to be read as the `compatibility` part instead of `prerelease`

see https://docs.renovatebot.com/modules/versioning/regex/