### PR TITLE
Switch AWS access to use ESC

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -11,6 +11,8 @@ env:
 
 jobs:
   acceptance-tests:
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ inputs.folder }}-test-${{ github.sha }}-${{ matrix.index }}
@@ -25,15 +27,14 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.11.0
         with:
           repo: pulumi/pulumictl
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: Generate Pulumi Access Token
+        uses: pulumi/auth-actions@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-region: ${{ env.AWS_REGION }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 3600
-          role-session-name: pulumi-cdk@githubActions
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          organization: pulumi
+          requested-token-type: urn:pulumi:token-type:access_token:organization
+      - uses: pulumi/esc-action@v1
+        with:
+          environment: logins/pulumi-ci
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
This switches the AWS Access from hardcoded access keys that are pulled
from GitHub secrets to use Pulumi ESC environments.

re #3731