### PR TITLE
Automate renovate updates for CDK dependencies

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -23,12 +23,27 @@
       matchDatasources: ["npm"],
       matchPackageNames: ["@aws-cdk/cli-lib-alpha"],
       matchDepTypes: ["dependencies"],
+      groupName: "upstream AWS CDK dependencies",
+      groupSlug: "cdk",
+      // automatically bump these, don't require manual trigger
+      dependencyDashboardApproval: false,
       // renovate can't handle the alpha versioning scheme (it expects major.minor.patch to always be the same)
       // In this case it is the `-alpha.0` that always stays the same
       // Here we tell renovate how to read the versioning. The important part
       // is that we switch the `-alpha.0` to be the `compatibility` part instead of `prerelease`
       // see https://docs.renovatebot.com/modules/versioning/regex/
       versioning: "regex:^\\^?(?<major>\\d+)\\.((?<minor>\\d+))\\.((?<patch>\\d+))-(?<compatibility>.*)$",
+    },
+    {
+      // bump this with cli-lib-alpha so we are testing on the latest cdk version
+      matchDatasources: ["npm"],
+      matchPackageNames: ["aws-cdk-lib"],
+      matchDepTypes: ["dependencies", "devDependencies"],
+      groupName: "upstream AWS CDK dependencies",
+      groupSlug: "cdk",
+      // automatically bump these, don't require manual trigger
+      dependencyDashboardApproval: false,
+      rangeStrategy: "pin",
     },
   ]
 }


### PR DESCRIPTION
Follow up to #345 which was supposed to automate the CDK upstream
updates, but did not. The previous PRs only enabled us to manually
trigger the upgrades. This PR sets `dependencyDashboardApproval: false`
which is required for renovate to automatically create the PR when there
are version bumps.

This also adds the `aws-cdk-lib` dependency to the cdk group so that the
cdk dependencies are upgraded together.