### PR TITLE
Move nightly acceptance test schedule to 03:00 UTC

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
 name: main
 "on":
   schedule:
-    - cron: '0 7 * * *'
+    - cron: '0 3 * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
Moves the nightly acceptance-test cron from `0 7 * * *` to `0 3 * * *`.

The acceptance and integration jobs only run on the `schedule` event, so this cron alone decides when they exercise AWS. GitHub dispatches scheduled runs late (last 25 nightlies here: 34–124 min, median 67), so `0 7` has in practice been starting the suite around 08:07, which collides with a recurring account maintenance sweep that runs at 00:00/08:00/16:00 UTC. `0 3` keeps the effective window clear of those on either side even at the worst delay observed, and still returns results before the working day.

Stopgap only; root cause is tracked in pulumi/home#4853.

Part of #564